### PR TITLE
Switch to ElementTree as primary iterator

### DIFF
--- a/clinvar_ingest/model.py
+++ b/clinvar_ingest/model.py
@@ -72,9 +72,9 @@ class VariationArchive(Model):
     def from_xml(inp: dict):
         _logger.info(f"VariationArchive.from_xml(inp={json.dumps(inp)})")
         return VariationArchive(
-            id=inp["Accession"],
-            name=inp["VariationName"],
-            version=inp["Version"],
+            id=inp["@Accession"],
+            name=inp["@VariationName"],
+            version=inp["@Version"],
             variation=Variation.from_xml(
                 inp.get("InterpretedRecord", inp.get("IncludedRecord"))
             ),


### PR DESCRIPTION
Parse ReleaseDate from root element. 

Switching to ElementTree lets me get rid of the threading, queue, and callback stuff. Still use xmltodict to convert individual elements to Python dicts.