### PR TITLE
Changes for asynchronous workflow execution using a run id and state files

### DIFF
--- a/.cloudbuild/workflow-py.docker.cloudbuild.yaml
+++ b/.cloudbuild/workflow-py.docker.cloudbuild.yaml
@@ -1,0 +1,10 @@
+steps:
+- name: 'gcr.io/kaniko-project/executor:v1.3.0'
+  args:
+  - --destination=gcr.io/clingen-dev/clinvar-ingest:${COMMIT_SHA}
+  # - --destination=gcr.io/clingen-dev/clinvar-ingest:latest
+  - --dockerfile=Dockerfile-workflow-py
+  - --cache=true
+  - --cache-ttl=168h
+
+timeout: 1800s

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,13 @@ RUN python -m pip install .
 
 # Runtime Image
 FROM python:3.11-slim-bullseye as runtime
+RUN apt update && apt install -y curl
 COPY --from=build /opt/venv /opt/venv
 COPY log_conf.json /app/log_conf.json
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 ENV GCLOUD_PROJECT="clingen-dev"
+
+
 
 CMD ["uvicorn", "clinvar_ingest.api.main:app", "--host", "0.0.0.0", "--port", "80", "--log-config", "/app/log_conf.json"]

--- a/Dockerfile-workflow-py
+++ b/Dockerfile-workflow-py
@@ -1,0 +1,28 @@
+# docker build -t gcr.io/clingen-dev/clinvar-ingest-workflow-py:latest -f Dockerfile-workflow-py .
+
+# gcloud run jobs execute clinvar-ingest-workflow-py --region us-central1 --update-env-vars='directory=/pub/clinvar/xml/VCV_xml_old_format,host=https://ftp.ncbi.nlm.nih.gov/,last_modified=2024-01-07T15:47:16,name=ClinVarVariationRelease_2024-02.xml.gz,release_date=2024-02-01,released=2024-02-01T15:47:16,size=3298023159'
+
+# Build Image
+FROM python:3.11-slim-bullseye as build
+
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+WORKDIR /app
+COPY ./clinvar_ingest ./clinvar_ingest
+COPY pyproject.toml .
+RUN python -m pip install .
+
+# Runtime Image
+FROM python:3.11-slim-bullseye as runtime
+RUN apt update && apt install -y curl
+COPY --from=build /opt/venv /opt/venv
+COPY log_conf.json /app/log_conf.json
+COPY misc/bin/workflow.py /app/workflow.py
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ENV GCLOUD_PROJECT="clingen-dev"
+
+
+CMD ["python3", "/app/workflow.py"]

--- a/clinvar_ingest/.dev.env
+++ b/clinvar_ingest/.dev.env
@@ -1,3 +1,2 @@
-BQ_DEST_DATASET=clinvar_ingest_main_deploy
+
 BQ_DEST_PROJECT=clingen-dev
-PARSE_OUTPUT_PREFIX=gs://clinvar-ingest/main-release-outputs

--- a/clinvar_ingest/api/main.py
+++ b/clinvar_ingest/api/main.py
@@ -65,7 +65,7 @@ async def health():
 )
 async def create_workflow_execution_id(initial_id: str):
     assert initial_id is not None and len(initial_id) > 0
-    timestamp = datetime.utcnow().isoformat().replace(":", "").replace(".", "")
+    timestamp = datetime.utcnow().isoformat().replace(":", "").replace(".", "").replace("-", "_")
     execution_id = f"{initial_id}_{timestamp}"
     return InitializeWorkflowResponse(workflow_execution_id=execution_id)
 

--- a/clinvar_ingest/api/main.py
+++ b/clinvar_ingest/api/main.py
@@ -5,7 +5,6 @@ from pathlib import PurePosixPath
 
 from fastapi import BackgroundTasks, FastAPI, HTTPException, Request, status
 from google.cloud import bigquery
-from google.cloud.storage import Client as GCSClient
 
 import clinvar_ingest.config
 from clinvar_ingest.api.middleware import LogRequests
@@ -30,7 +29,11 @@ from clinvar_ingest.api.status_file import (
     write_status_file,
 )
 from clinvar_ingest.cloud.bigquery.create_tables import run_create_external_tables
-from clinvar_ingest.cloud.gcs import copy_file_to_bucket, http_download_curl
+from clinvar_ingest.cloud.gcs import (
+    _get_gcs_client,
+    copy_file_to_bucket,
+    http_download_curl,
+)
 from clinvar_ingest.parse import parse_and_write_files
 from clinvar_ingest.status import StepName
 
@@ -46,12 +49,6 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(lifespan=lifespan, openapi_url="/openapi.json", docs_url="/api")
 app.add_middleware(LogRequests)
-
-
-def _get_gcs_client() -> GCSClient:
-    if getattr(_get_gcs_client, "client", None) is None:
-        setattr(_get_gcs_client, "client", GCSClient())
-    return getattr(_get_gcs_client, "client")
 
 
 @app.get("/health", status_code=status.HTTP_200_OK)

--- a/clinvar_ingest/api/main.py
+++ b/clinvar_ingest/api/main.py
@@ -3,7 +3,7 @@ from contextlib import asynccontextmanager
 from datetime import datetime
 from pathlib import PurePosixPath
 
-from fastapi import FastAPI, HTTPException, Request, status, BackgroundTasks
+from fastapi import BackgroundTasks, FastAPI, HTTPException, Request, status
 from google.cloud import bigquery
 from google.cloud.storage import Client as GCSClient
 
@@ -14,7 +14,6 @@ from clinvar_ingest.api.model.requests import (
     CopyResponse,
     CreateExternalTablesRequest,
     CreateExternalTablesResponse,
-    GetStepStatusRequest,
     GetStepStatusResponse,
     InitializeStepRequest,
     InitializeStepResponse,
@@ -207,7 +206,7 @@ async def fake_step(
     status_code=status.HTTP_201_CREATED,
     response_model=StepStartedResponse,
 )
-def copy(
+async def copy(
     request: Request,
     workflow_execution_id: str,
     payload: ClinvarFTPWatcherRequest,
@@ -334,31 +333,3 @@ async def create_internal_tables(payload: TodoRequest):
 @app.post("/create_cleaned_tables", status_code=status.HTTP_201_CREATED)
 async def create_cleaned_tables(payload: TodoRequest):
     return {"todo": "implement me"}
-
-
-def sleep_1(request: Request):
-    import time
-
-    time.sleep(5)
-    return {}
-
-
-def sleep_2(request: Request):
-    import asyncio
-
-    asyncio.sleep(5)
-    return {}
-
-
-async def sleep_3(request: Request):
-    import time
-
-    time.sleep(5)
-    return {}
-
-
-async def sleep_4(request: Request):
-    import asyncio
-
-    asyncio.sleep(5)
-    return {}

--- a/clinvar_ingest/api/main.py
+++ b/clinvar_ingest/api/main.py
@@ -77,11 +77,11 @@ async def initialize_step(request: Request, payload: InitializeStepRequest):
     message = payload.message
 
     status_value = write_status_file(
-        file_prefix=f"{workflow_execution_id}/{env.job_status_prefix}",
+        bucket=env.bucket_name,
+        file_prefix=f"{env.executions_output_prefix}/{workflow_execution_id}",
         step=step_name,
         status=step_status,
         message=message,
-        timestamp=datetime.utcnow().isoformat(),
     )
 
     return InitializeStepResponse(

--- a/clinvar_ingest/api/main.py
+++ b/clinvar_ingest/api/main.py
@@ -220,6 +220,7 @@ async def copy(
     ftp_base = str(payload.host).strip("/")
     ftp_dir = PurePosixPath(payload.directory)
     ftp_file = PurePosixPath(payload.name)
+    ftp_file_size = payload.size
     ftp_path = f"{ftp_base}/{ftp_dir.relative_to(ftp_dir.anchor) / ftp_file}"
 
     gcs_base = (
@@ -241,7 +242,7 @@ async def copy(
 
     def task():
         try:
-            http_upload_urllib(ftp_path, gcs_path, client=_get_gcs_client())
+            http_upload_urllib(ftp_path, gcs_path, ftp_file_size, client=_get_gcs_client())
             write_status_file(
                 env.bucket_name,
                 f"{env.executions_output_prefix}/{workflow_execution_id}",

--- a/clinvar_ingest/api/main.py
+++ b/clinvar_ingest/api/main.py
@@ -92,7 +92,7 @@ async def initialize_step(request: Request, payload: InitializeStepRequest):
     )
 
 
-@app.get("/get_step_status", status_code=status.HTTP_200_OK)
+@app.get("/step_status", status_code=status.HTTP_200_OK)
 async def get_step_status(request: Request, payload: GetStepStatusRequest):
     env: clinvar_ingest.config.Env = request.app.env
     execution_status_directory = (
@@ -100,6 +100,13 @@ async def get_step_status(request: Request, payload: GetStepStatusRequest):
     )
     status_gcs_path = f"gs://{env.bucket_name}/{execution_status_directory}"
     logger.debug("Reading status from %s", status_gcs_path)
+
+
+# TODO
+# it would be useful to have a /workflow_execution_status endpoint that returns the
+# status of all steps instead of needing to specify a specific step to check. If
+# the status filenames are consistent we can check each one and return a
+# dict of step_name -> {status info}
 
 
 @app.post("/copy", status_code=status.HTTP_201_CREATED, response_model=CopyResponse)

--- a/clinvar_ingest/api/main.py
+++ b/clinvar_ingest/api/main.py
@@ -65,7 +65,7 @@ async def health():
 )
 async def create_workflow_execution_id(initial_id: str):
     assert initial_id is not None and len(initial_id) > 0
-    timestamp = datetime.utcnow().isoformat()
+    timestamp = datetime.utcnow().isoformat().replace(":", "").replace(".", "")
     execution_id = f"{initial_id}_{timestamp}"
     return InitializeWorkflowResponse(workflow_execution_id=execution_id)
 

--- a/clinvar_ingest/api/model/requests.py
+++ b/clinvar_ingest/api/model/requests.py
@@ -181,6 +181,7 @@ class CreateExternalTablesRequest(BaseModel):
             raise ValueError(
                 f"destination_dataset must match pattern {pattern}. Got: {v}"
             )
+        return v
 
 
 class CreateExternalTablesResponse(RootModel):

--- a/clinvar_ingest/api/model/requests.py
+++ b/clinvar_ingest/api/model/requests.py
@@ -184,14 +184,6 @@ class InitializeStepResponse(BaseModel):
     step_status: StepStatus
     timestamp: datetime
 
-    # @field_validator("timestamp")
-    # @classmethod
-    # def _timestamp_validator(cls, v: datetime):
-    #     if v.tzinfo == "UTC":
-    #         raise ValueError("Timestamp must be timezone aware")
-    #     if v.tzinfo is not None:
-    #         raise ValueError("Timestamp must be timezone aware")
-
     @field_serializer("timestamp", when_used="always")
     def _timestamp_serializer(self, v: datetime):
         return v.isoformat()

--- a/clinvar_ingest/api/model/requests.py
+++ b/clinvar_ingest/api/model/requests.py
@@ -131,7 +131,7 @@ class CreateExternalTablesRequest(BaseModel):
     source_table_paths: dict[str, GcsBlobPath]
 
 
-bigquery_full_table_id = Annotated[
+BigqueryFullTableId = Annotated[
     str, StringConstraints(pattern=r"^[a-zA-Z0-9-_]+:[a-zA-Z0-9_]+.[a-zA-Z0-9-_]+$")
 ]
 
@@ -141,7 +141,24 @@ class CreateExternalTablesResponse(RootModel):
     Map of entity type to full table id (project:dataset.table)
     """
 
-    root: dict[str, bigquery_full_table_id]
+    root: dict[str, BigqueryFullTableId]
+
+
+class InitializeWorkflowResponse(BaseModel):
+    """
+    Defines the response from create_workflow_id endpoint.
+    """
+
+    workflow_id: Annotated[
+        str,
+        Field(
+            description=(
+                "The base value to be used to initialize a workflow ID. "
+                "The workflow ID will be a concatenation of this value and a timestamp. "
+                "For example a value of '2024-01-24' will result in a workflow ID of '2024-01-24_<timestamp>'."
+            )
+        ),
+    ]
 
 
 class TodoRequest(BaseModel):  # A shim to get the workflow pieced together

--- a/clinvar_ingest/api/model/requests.py
+++ b/clinvar_ingest/api/model/requests.py
@@ -130,6 +130,7 @@ class CreateExternalTablesRequest(BaseModel):
     Values are used by create_tables.run_create_external_tables.
     """
 
+    destination_dataset: str
     source_table_paths: dict[str, GcsBlobPath]
 
 

--- a/clinvar_ingest/api/model/requests.py
+++ b/clinvar_ingest/api/model/requests.py
@@ -1,6 +1,6 @@
 from datetime import date, datetime
 from pathlib import PurePath
-from typing import Annotated, Any, Callable, Union
+from typing import Annotated, Any, Callable, Literal, Optional, Union
 
 from pydantic import (
     AnyUrl,
@@ -171,7 +171,7 @@ class InitializeStepRequest(BaseModel):
 
     workflow_execution_id: str
     step_name: StepName
-    message: str = None
+    message: Optional[str] = None
 
 
 class InitializeStepResponse(BaseModel):
@@ -196,6 +196,39 @@ class GetStepStatusRequest(BaseModel):
 
     workflow_execution_id: str
     step_name: StepName
+
+
+class GetStepStatusResponse(BaseModel):
+    """
+    Defines the response from the get_step_status endpoint.
+    """
+
+    workflow_execution_id: str
+    step_name: StepName
+    step_status: StepStatus
+    timestamp: datetime
+    message: Optional[str] = None
+
+    @field_serializer("timestamp", when_used="always")
+    def _timestamp_serializer(self, v: datetime):
+        return v.isoformat()
+
+
+class StepStartedResponse(BaseModel):
+    """
+    Defines the response from the step_started endpoint.
+    """
+
+    workflow_execution_id: str
+    step_name: StepName
+
+    timestamp: datetime
+    step_status: Literal[StepStatus.STARTED] = StepStatus.STARTED
+    message: Optional[str] = None
+
+    @field_serializer("timestamp", when_used="always")
+    def _timestamp_serializer(self, v: datetime):
+        return v.isoformat()
 
 
 class TodoRequest(BaseModel):  # A shim to get the workflow pieced together

--- a/clinvar_ingest/api/model/requests.py
+++ b/clinvar_ingest/api/model/requests.py
@@ -58,7 +58,7 @@ BigqueryFullTableId = Annotated[
 
 
 def strict_datetime_field_validator(cls, v, info: ValidationInfo) -> datetime:
-    print(f"Validating {info.field_name} with value {v}")
+    # print(f"Validating {info.field_name} with value {v}")
     if not v:
         raise ValueError(f"{info.field_name} was empty")
     if isinstance(v, datetime):

--- a/clinvar_ingest/api/status_file.py
+++ b/clinvar_ingest/api/status_file.py
@@ -2,7 +2,9 @@
 This module is for creating and writing messages to status files for workflow jobs so that external
 services can monitor the status of the workflow jobs. The status files are written to a GCS bucket.
 """
+
 import json
+import logging
 from datetime import datetime
 
 from google.cloud.storage import Blob
@@ -10,6 +12,8 @@ from google.cloud.storage import Client as GCSClient
 
 from clinvar_ingest.cloud.gcs import blob_writer
 from clinvar_ingest.status import StatusValue, StepName, StepStatus
+
+logger = logging.getLogger(__name__)
 
 
 def write_status_file(
@@ -36,6 +40,7 @@ def write_status_file(
     )
 
     gcs_uri = f"gs://{bucket}/{file_prefix}/{step}-{status}.json"
+    logger.debug(f"Writing status file to {gcs_uri} with content: {status_value}")
     with blob_writer(gcs_uri) as writer:
         writer.write(json.dumps(vars(status_value)).encode("utf-8"))
     return status_value

--- a/clinvar_ingest/api/status_file.py
+++ b/clinvar_ingest/api/status_file.py
@@ -41,6 +41,9 @@ def write_status_file(
     return status_value
 
 
+# TODO an improvement here for performance reasons in the status check endpoint
+# would be to make blob existence knowable without necessarily downloading the blob
+# a finished workflow step would not need to download the started file to know it's finished
 def get_status_file(
     bucket: str,
     file_prefix: str,

--- a/clinvar_ingest/api/status_file.py
+++ b/clinvar_ingest/api/status_file.py
@@ -6,16 +6,16 @@ import json
 from datetime import datetime
 
 from clinvar_ingest.cloud.gcs import blob_writer
-from clinvar_ingest.config import Env, get_env
 from clinvar_ingest.status import StatusValue, StepName, StepStatus
 
 
 def write_status_file(
+    bucket: str,
     file_prefix: str,
     step: StepName,
     status: StepStatus,
     message: str = None,
-    timestamp: datetime = datetime.now(),
+    timestamp: str = datetime.utcnow().isoformat(),
 ) -> StatusValue:
     """
     This function writes a status file to a GCS bucket. The status file is a JSON file with the following format:
@@ -25,22 +25,14 @@ def write_status_file(
         "message": "All files copied successfully",
         "timestamp": "2021-06-24T16:12:00.000000"
     }
+
+    TODO maybe make a way to run this locally for testing, not writing to a bucket.
     """
     status_value = StatusValue(
         status=status, step=step, timestamp=timestamp, message=message
     )
-    env: Env = get_env()
-    gcs_uri = f"gs://{env.bucket_name}/{env.job_status_prefix}/{step}-{status}.json"
+
+    gcs_uri = f"gs://{bucket}/{file_prefix}/{step}-{status}.json"
     with blob_writer(gcs_uri) as writer:
         writer.write(json.dumps(vars(status_value)).encode("utf-8"))
     return status_value
-
-
-"""
-job_id = "2024-01-24_<timestamp>"
-
-# TODO make the output directory paths nest under the job_id
-
-
-
-"""

--- a/clinvar_ingest/api/status_file.py
+++ b/clinvar_ingest/api/status_file.py
@@ -1,0 +1,46 @@
+"""
+This module is for creating and writing messages to status files for workflow jobs so that external
+services can monitor the status of the workflow jobs. The status files are written to a GCS bucket.
+"""
+import json
+from datetime import datetime
+
+from clinvar_ingest.cloud.gcs import blob_writer
+from clinvar_ingest.config import Env, get_env
+from clinvar_ingest.status import StatusValue, StepName, StepStatus
+
+
+def write_status_file(
+    file_prefix: str,
+    step: StepName,
+    status: StepStatus,
+    message: str = None,
+    timestamp: datetime = datetime.now(),
+) -> StatusValue:
+    """
+    This function writes a status file to a GCS bucket. The status file is a JSON file with the following format:
+    {
+        "status": "succeeded",
+        "step": "COPY",
+        "message": "All files copied successfully",
+        "timestamp": "2021-06-24T16:12:00.000000"
+    }
+    """
+    status_value = StatusValue(
+        status=status, step=step, timestamp=timestamp, message=message
+    )
+    env: Env = get_env()
+    gcs_uri = f"gs://{env.bucket_name}/{env.job_status_prefix}/{step}-{status}.json"
+    with blob_writer(gcs_uri) as writer:
+        writer.write(json.dumps(vars(status_value)).encode("utf-8"))
+    return status_value
+
+
+"""
+job_id = "2024-01-24_<timestamp>"
+
+# TODO make the output directory paths nest under the job_id
+
+
+
+"""

--- a/clinvar_ingest/api/status_file.py
+++ b/clinvar_ingest/api/status_file.py
@@ -5,7 +5,8 @@ services can monitor the status of the workflow jobs. The status files are writt
 import json
 from datetime import datetime
 
-from google.cloud.storage import Client as GCSClient, Blob
+from google.cloud.storage import Blob
+from google.cloud.storage import Client as GCSClient
 
 from clinvar_ingest.cloud.gcs import blob_writer
 from clinvar_ingest.status import StatusValue, StepName, StepStatus

--- a/clinvar_ingest/api/status_file.py
+++ b/clinvar_ingest/api/status_file.py
@@ -13,7 +13,7 @@ from google.cloud.storage import Client as GCSClient
 from clinvar_ingest.cloud.gcs import blob_writer
 from clinvar_ingest.status import StatusValue, StepName, StepStatus
 
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger("clinvar_ingest")
 
 
 def write_status_file(
@@ -40,7 +40,7 @@ def write_status_file(
     )
 
     gcs_uri = f"gs://{bucket}/{file_prefix}/{step}-{status}.json"
-    logger.debug(f"Writing status file to {gcs_uri} with content: {status_value}")
+    _logger.debug(f"Writing status file to {gcs_uri} with content: {status_value}")
     with blob_writer(gcs_uri) as writer:
         writer.write(json.dumps(vars(status_value)).encode("utf-8"))
     return status_value

--- a/clinvar_ingest/cli.py
+++ b/clinvar_ingest/cli.py
@@ -51,7 +51,6 @@ def parse_args(argv):
 
     # CREATE TABLES
     create_table_sp = subparsers.add_parser("create-tables")
-    create_table_sp.add_argument("--destination-project", type=str, required=False)
     create_table_sp.add_argument("--destination-dataset", type=str, required=True)
     create_table_sp.add_argument("--source-table-paths", type=json.loads, required=True)
 

--- a/clinvar_ingest/cloud/bigquery/create_tables.py
+++ b/clinvar_ingest/cloud/bigquery/create_tables.py
@@ -111,13 +111,15 @@ def run_create_external_tables(
     dataset_obj = ensure_dataset_exists(
         bq_client,
         project=destination_project,
-        dataset_id=env.bq_dest_dataset,
+        dataset_id=args.destination_dataset,
         location=bucket_location,
     )
     if not dataset_obj:
         raise RuntimeError(f"Didn't get a dataset object back. run_create args: {args}")
 
     outputs = {}
+    # TODO maybe do something more clever if it fails part way through
+    # but maybe not, it could be useful to see the partial results
     for table_name, gcs_blob_path in args.source_table_paths.items():
         table = create_table(
             table_name,

--- a/clinvar_ingest/cloud/bigquery/create_tables.py
+++ b/clinvar_ingest/cloud/bigquery/create_tables.py
@@ -17,7 +17,7 @@ from clinvar_ingest.api.model.requests import CreateExternalTablesRequest
 from clinvar_ingest.cloud.gcs import parse_blob_uri
 from clinvar_ingest.config import get_env
 
-_logger = logging.getLogger(__name__)
+_logger = logging.getLogger("clinvar_ingest")
 
 file_dir = Path(__file__).parent.resolve()
 bq_schemas_dir = file_dir / "bq_json_schemas"

--- a/clinvar_ingest/cloud/bigquery/create_tables.py
+++ b/clinvar_ingest/cloud/bigquery/create_tables.py
@@ -5,6 +5,7 @@ files from Google Cloud Storage.
 
 Usable as a script or programmatic module.
 """
+
 import logging
 from pathlib import Path
 
@@ -96,6 +97,9 @@ def run_create_external_tables(
     source_buckets = set()
     for table_name, gcs_blob_path in args.source_table_paths.items():
         parsed_blob = parse_blob_uri(gcs_blob_path.root, gcs_client)
+        _logger.info(
+            "Parsed blob bucket: %s, path: %s", parsed_blob.bucket, parsed_blob.name
+        )
         bucket_obj = gcs_client.get_bucket(parsed_blob.bucket.name)
         bucket_location = bucket_obj.location
         source_buckets.add(parsed_blob.bucket.name)

--- a/clinvar_ingest/cloud/gcs.py
+++ b/clinvar_ingest/cloud/gcs.py
@@ -1,10 +1,14 @@
 import logging
+import queue
+import subprocess
+import threading
 import time
-import urllib
+from pathlib import Path, PurePath
 
+import requests
 from google.cloud import storage
 
-_logger = logging.getLogger(__name__)
+_logger = logging.getLogger("clinvar_ingest")
 
 
 def parse_blob_uri(uri: str, client: storage.Client = None) -> storage.Blob:
@@ -57,7 +61,7 @@ def blob_reader(
     return blob.open("rb" if binary else "r")
 
 
-def http_upload_urllib(
+def http_upload(
     http_uri: str,
     blob_uri: str,
     file_size: int,
@@ -65,40 +69,153 @@ def http_upload_urllib(
     chunk_size=8 * 1024 * 1024,
 ):
     """
-    Upload the contents of `http_uri` to `blob_uri` using urllib.request.urlopen and Blob.open
+    Upload the contents of `http_uri` to `blob_uri` using requests.get and Blob.open
     """
     _logger.info(f"Uploading {http_uri} to {blob_uri}")
     if client is None:
         client = storage.Client()
 
     bytes_read = 0
-    with urllib.request.urlopen(http_uri) as f:
-        opened_file_size = int(f.headers.get("Content-Length"))
-        if opened_file_size != file_size:
-            raise RuntimeError(
-                f"File size mismatch. Expected {file_size} but got {opened_file_size}."
-            )
-        with blob_writer(blob_uri=blob_uri, client=client) as f_out:
-            while bytes_read < file_size:
-                chunk = f.read(chunk_size)
-                chunk_bytes_read = len(chunk)
-                bytes_read += chunk_bytes_read
-                _logger.info(
-                    f"Read {chunk_bytes_read} bytes from {http_uri}. Total bytes read: {bytes_read}."
-                )
-
-                if len(chunk) > 0:
-                    f_out.write(chunk)
-
-                if len(chunk) == 0:
-                    wait_time = 10
-                    _logger.warning(
-                        f"Received an empty chunk from {http_uri} at byte {bytes_read}. Pausing {wait_time} seconds"
-                    )
-                    time.sleep(wait_time)
-
-    # Sanity check for bytes read == file_size
-    if bytes_read != file_size:
+    response = requests.get(http_uri, stream=True, timeout=10)
+    response.raise_for_status()
+    opened_file_size = int(response.headers.get("Content-Length"))
+    if opened_file_size != file_size:
         raise RuntimeError(
-            f"Upload of {http_uri} to {blob_uri} failed. Read {bytes_read} of {file_size}."
+            f"File size mismatch. Expected {file_size} but got {opened_file_size}."
         )
+    with blob_writer(blob_uri=blob_uri, client=client) as f_out:
+        for chunk in response.iter_content(chunk_size=chunk_size):
+            chunk_bytes_read = len(chunk)
+            bytes_read += chunk_bytes_read
+            _logger.info(
+                f"Read {chunk_bytes_read} bytes from {http_uri}. Total bytes read: {bytes_read}/{opened_file_size}."
+            )
+
+            if len(chunk) > 0:
+                f_out.write(chunk)
+
+            if len(chunk) == 0:
+                wait_time = 10
+                _logger.warning(
+                    f"Received an empty chunk from {http_uri} at byte {bytes_read}. Pausing {wait_time} seconds"
+                )
+                time.sleep(wait_time)
+
+
+def http_download_requests(
+    http_uri: str,
+    local_path: PurePath,
+    file_size: int,
+    chunk_size=8 * 1024 * 1024,
+):
+    """
+    Upload the contents of `http_uri` to `blob_uri` using requests.get and Blob.open
+    """
+    _logger.info(f"Downloading {http_uri} to {local_path}")
+
+    bytes_read = 0
+    response = requests.get(http_uri, stream=True, timeout=10)
+    response.raise_for_status()
+    opened_file_size = int(response.headers.get("Content-Length"))
+
+    def log_progress():
+        if getattr(log_progress, "prev_log_time", None) is None:
+            log_progress.prev_log_time = time.time()
+            log_progress.prev_log_bytes = 0
+            return
+        now = time.time()
+        if now - log_progress.prev_log_time > 5:
+            elapsed = now - log_progress.prev_log_time
+            elapsed_bytes = bytes_read - log_progress.prev_log_bytes
+            _logger.info(
+                f"Read {elapsed_bytes} bytes in {elapsed:.2f} seconds. Total bytes read: {bytes_read}/{opened_file_size}."
+            )
+            log_progress.prev_log_time = now
+            log_progress.prev_log_bytes = bytes_read
+
+    log_progress()  # initialize
+
+    if opened_file_size != file_size:
+        raise RuntimeError(
+            f"File size mismatch. Expected {file_size} but got {opened_file_size}."
+        )
+    with open(local_path, "wb") as f_out:
+        for chunk in response.iter_content(chunk_size=chunk_size):
+            chunk_bytes_read = len(chunk)
+            bytes_read += chunk_bytes_read
+
+            log_progress()
+
+            if len(chunk) > 0:
+                f_out.write(chunk)
+
+            if len(chunk) == 0:
+                wait_time = 10
+                _logger.warning(
+                    f"Received an empty chunk from {http_uri} at byte {bytes_read}. Pausing {wait_time} seconds"
+                )
+                time.sleep(wait_time)
+
+    return Path(local_path)
+
+
+def http_download_curl(
+    http_uri: str,
+    local_path: PurePath,
+    file_size: int,
+    # client: storage.Client = None,
+    # chunk_size=8 * 1024 * 1024,
+) -> Path:
+    p = subprocess.Popen(
+        ["curl", "-o", local_path, http_uri],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    def reader(pipe: subprocess.PIPE, q: queue.Queue):
+        try:
+            with pipe:
+                for line in iter(pipe.readline, b""):
+                    q.put((pipe, line))
+        finally:
+            q.put(None)
+
+    q = queue.Queue()
+    t1 = threading.Thread(target=reader, args=(p.stdout, q))
+    t1.start()
+    t2 = threading.Thread(target=reader, args=(p.stderr, q))
+    t2.start()
+
+    def file_stat(path: Path, q: queue.Queue):
+        while True:
+            try:
+                _ = q.get_nowait()
+                break
+            except queue.Empty:
+                if not path.exists():
+                    _logger.info(f"{path} does not exist")
+                else:
+                    _logger.info(f"{path} size: {path.stat().st_size}")
+            time.sleep(10)
+
+    t_stat_stop = queue.Queue()
+    t_stat = threading.Thread(target=file_stat, args=(Path(local_path), t_stat_stop))
+    t_stat.start()
+
+    for _ in range(2):
+        for pipe, line in iter(q.get, None):
+            _logger.info(f"{pipe}: {line.decode('utf-8')}")
+
+    returncode = p.wait()
+    _logger.info(f"curl return code: {returncode}")
+
+    t_stat_stop.put(None)
+
+    actual_path = Path(local_path)
+    if not actual_path.exists():
+        raise RuntimeError(f"File {local_path} does not exist")
+    if actual_path.stat().st_size != file_size:
+        raise RuntimeError(
+            f"File size mismatch. Expected {file_size} but got {actual_path.stat().st_size}."
+        )
+    return actual_path

--- a/clinvar_ingest/cloud/gcs.py
+++ b/clinvar_ingest/cloud/gcs.py
@@ -91,12 +91,7 @@ def http_upload_urllib(
                         f"Received an empty chunk from {http_uri} at byte {bytes_read}."
                     )
 
-            # Sanity check for bytes read == file_size
-            if bytes_read != file_size:
-                raise RuntimeError(
-                    f"Error uploading {http_uri} to {blob_uri}. Read {bytes_read} of {file_size}."
-                )
-
+    # Sanity check for bytes read == file_size
     if bytes_read != file_size:
         raise RuntimeError(
             f"Upload of {http_uri} to {blob_uri} failed. Read {bytes_read} of {file_size}."

--- a/clinvar_ingest/cloud/gcs.py
+++ b/clinvar_ingest/cloud/gcs.py
@@ -1,4 +1,5 @@
 import logging
+import time
 import urllib
 
 from google.cloud import storage
@@ -82,14 +83,19 @@ def http_upload_urllib(
                 chunk = f.read(chunk_size)
                 chunk_bytes_read = len(chunk)
                 bytes_read += chunk_bytes_read
+                _logger.info(
+                    f"Read {chunk_bytes_read} bytes from {http_uri}. Total bytes read: {bytes_read}."
+                )
 
                 if len(chunk) > 0:
                     f_out.write(chunk)
 
                 if len(chunk) == 0:
+                    wait_time = 10
                     _logger.warning(
-                        f"Received an empty chunk from {http_uri} at byte {bytes_read}."
+                        f"Received an empty chunk from {http_uri} at byte {bytes_read}. Pausing {wait_time} seconds"
                     )
+                    time.sleep(wait_time)
 
     # Sanity check for bytes read == file_size
     if bytes_read != file_size:

--- a/clinvar_ingest/config.py
+++ b/clinvar_ingest/config.py
@@ -7,8 +7,8 @@ from pydantic import BaseModel
 _bucket_name = os.environ.get("CLINVAR_INGEST_BUCKET", "")
 _bucket_staging_prefix = os.environ.get("CLINVAR_INGEST_STAGING_PREFIX", "clinvar_xml")
 _bucket_parsed_prefix = os.environ.get("CLINVAR_INGEST_PARSED_PREFIX", "clinvar_parsed")
-_bucket_job_status_prefix = os.environ.get(
-    "CLINVAR_INGEST_JOB_STATUS_PREFIX", "job_statuses"
+_bucket_executions_prefix = os.environ.get(
+    "CLINVAR_INGEST_EXECUTIONS_PREFIX", "executions"
 )
 _clinvar_ftp_base_url = os.environ.get(
     "CLINVAR_FTP_BASE_URL", "https://ftp.ncbi.nlm.nih.gov"
@@ -25,7 +25,7 @@ class Env(BaseModel):
     bucket_parsed_prefix: str
     clinvar_ftp_base_url: str
     parse_output_prefix: str
-    job_status_prefix: str
+    executions_output_prefix: str
 
 
 def get_env() -> Env:
@@ -41,5 +41,5 @@ def get_env() -> Env:
         bucket_parsed_prefix=_bucket_parsed_prefix,
         clinvar_ftp_base_url=_clinvar_ftp_base_url,
         parse_output_prefix=_dotenv_values["PARSE_OUTPUT_PREFIX"],
-        job_status_prefix=_bucket_job_status_prefix,
+        executions_output_prefix=_bucket_executions_prefix,
     )

--- a/clinvar_ingest/config.py
+++ b/clinvar_ingest/config.py
@@ -10,20 +10,15 @@ _bucket_parsed_prefix = os.environ.get("CLINVAR_INGEST_PARSED_PREFIX", "clinvar_
 _bucket_executions_prefix = os.environ.get(
     "CLINVAR_INGEST_EXECUTIONS_PREFIX", "executions"
 )
-_clinvar_ftp_base_url = os.environ.get(
-    "CLINVAR_FTP_BASE_URL", "https://ftp.ncbi.nlm.nih.gov"
-)
 _dotenv_env = os.environ.get("DOTENV_ENV", "dev")
 _dotenv_values = dotenv_values(pathlib.Path(__file__).parent / f".{_dotenv_env}.env")
 
 
 class Env(BaseModel):
-    # bq_dest_dataset: str
     bq_dest_project: str
     bucket_name: str
     bucket_staging_prefix: str
     bucket_parsed_prefix: str
-    clinvar_ftp_base_url: str
     parse_output_prefix: str
     executions_output_prefix: str
 
@@ -41,12 +36,10 @@ def get_env() -> Env:
     variables and any default values.
     """
     return Env(
-        # bq_dest_dataset=_dotenv_values["BQ_DEST_DATASET"],
         bq_dest_project=_dotenv_values["BQ_DEST_PROJECT"],
-        bucket_name=_bucket_name,
+        bucket_name=_bucket_name or _dotenv_values["CLINVAR_INGEST_BUCKET"],
         bucket_staging_prefix=_bucket_staging_prefix,
         bucket_parsed_prefix=_bucket_parsed_prefix,
-        clinvar_ftp_base_url=_clinvar_ftp_base_url,
         parse_output_prefix=_bucket_parsed_prefix,
         executions_output_prefix=_bucket_executions_prefix,
     )

--- a/clinvar_ingest/config.py
+++ b/clinvar_ingest/config.py
@@ -7,6 +7,9 @@ from pydantic import BaseModel
 _bucket_name = os.environ.get("CLINVAR_INGEST_BUCKET", "")
 _bucket_staging_prefix = os.environ.get("CLINVAR_INGEST_STAGING_PREFIX", "clinvar_xml")
 _bucket_parsed_prefix = os.environ.get("CLINVAR_INGEST_PARSED_PREFIX", "clinvar_parsed")
+_bucket_job_status_prefix = os.environ.get(
+    "CLINVAR_INGEST_JOB_STATUS_PREFIX", "job_statuses"
+)
 _clinvar_ftp_base_url = os.environ.get(
     "CLINVAR_FTP_BASE_URL", "https://ftp.ncbi.nlm.nih.gov"
 )
@@ -22,6 +25,7 @@ class Env(BaseModel):
     bucket_parsed_prefix: str
     clinvar_ftp_base_url: str
     parse_output_prefix: str
+    job_status_prefix: str
 
 
 def get_env() -> Env:
@@ -37,4 +41,5 @@ def get_env() -> Env:
         bucket_parsed_prefix=_bucket_parsed_prefix,
         clinvar_ftp_base_url=_clinvar_ftp_base_url,
         parse_output_prefix=_dotenv_values["PARSE_OUTPUT_PREFIX"],
+        job_status_prefix=_bucket_job_status_prefix,
     )

--- a/clinvar_ingest/config.py
+++ b/clinvar_ingest/config.py
@@ -2,7 +2,7 @@ import os
 import pathlib
 
 from dotenv import dotenv_values
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 _bucket_name = os.environ.get("CLINVAR_INGEST_BUCKET", "")
 _bucket_staging_prefix = os.environ.get("CLINVAR_INGEST_STAGING_PREFIX", "clinvar_xml")
@@ -26,6 +26,13 @@ class Env(BaseModel):
     clinvar_ftp_base_url: str
     parse_output_prefix: str
     executions_output_prefix: str
+
+    @field_validator("bucket_name")
+    @classmethod
+    def _validate_bucket_name(cls, v, info):
+        if not v:
+            raise ValueError("CLINVAR_INGEST_BUCKET must be set")
+        return v
 
 
 def get_env() -> Env:

--- a/clinvar_ingest/config.py
+++ b/clinvar_ingest/config.py
@@ -40,6 +40,6 @@ def get_env() -> Env:
         bucket_staging_prefix=_bucket_staging_prefix,
         bucket_parsed_prefix=_bucket_parsed_prefix,
         clinvar_ftp_base_url=_clinvar_ftp_base_url,
-        parse_output_prefix=_dotenv_values["PARSE_OUTPUT_PREFIX"],
+        parse_output_prefix=_bucket_parsed_prefix,
         executions_output_prefix=_bucket_executions_prefix,
     )

--- a/clinvar_ingest/config.py
+++ b/clinvar_ingest/config.py
@@ -18,7 +18,7 @@ _dotenv_values = dotenv_values(pathlib.Path(__file__).parent / f".{_dotenv_env}.
 
 
 class Env(BaseModel):
-    bq_dest_dataset: str
+    # bq_dest_dataset: str
     bq_dest_project: str
     bucket_name: str
     bucket_staging_prefix: str
@@ -34,7 +34,7 @@ def get_env() -> Env:
     variables and any default values.
     """
     return Env(
-        bq_dest_dataset=_dotenv_values["BQ_DEST_DATASET"],
+        # bq_dest_dataset=_dotenv_values["BQ_DEST_DATASET"],
         bq_dest_project=_dotenv_values["BQ_DEST_PROJECT"],
         bucket_name=_bucket_name,
         bucket_staging_prefix=_bucket_staging_prefix,

--- a/clinvar_ingest/fs.py
+++ b/clinvar_ingest/fs.py
@@ -49,7 +49,27 @@ def find_files(root_directory: str) -> List[str]:
     return outputs
 
 
-def _open(filename: str, make_parents=True, mode: BinaryOpenMode = BinaryOpenMode.READ):
+class ReadCounter:
+    def __init__(self, f):
+        self.f = f
+        self.bytes_read = 0
+
+    def __getattr__(self, name):
+        return getattr(self.f, name)
+
+    def read(self, size=-1):
+        result = self.f.read(size)
+        assert isinstance(result, bytes), "ReadCounter only works with binary files."
+        self.bytes_read += len(result)
+        return result
+
+    def tell(self):
+        return self.bytes_read
+
+
+def fs_open(
+    filename: str, make_parents=True, mode: BinaryOpenMode = BinaryOpenMode.READ
+):
     """
     Opens a file with path `filename`. If `filename` ends in .gz, opens as gzip.
 

--- a/clinvar_ingest/main.py
+++ b/clinvar_ingest/main.py
@@ -10,7 +10,7 @@ from clinvar_ingest.cloud.gcs import copy_file_to_bucket
 from clinvar_ingest.fs import find_files
 from clinvar_ingest.parse import parse_and_write_files
 
-_logger = logging.getLogger("clinvar-ingest")
+_logger = logging.getLogger("clinvar_ingest")
 
 
 def run_parse(args):

--- a/clinvar_ingest/model.py
+++ b/clinvar_ingest/model.py
@@ -46,7 +46,6 @@ class Model(object, metaclass=ABCMeta):
 @dataclasses.dataclass
 class Submitter(Model):
     id: str
-    release_date: str
     current_name: str
     current_abbrev: str
     all_names: List[str]
@@ -66,12 +65,13 @@ class Submitter(Model):
             id=extract(inp, "@OrgID"),
             current_name=current_name,
             current_abbrev=current_abbrev,
-            release_date="",  # TODO - Fix
             org_category=extract(inp, "@OrganizationCategory"),
             all_names=[] if not current_name else [current_name],
             all_abbrevs=[] if not current_abbrev else [current_abbrev],
             content=inp,
         )
+        if jsonify_content:
+            obj.content = json.dumps(inp)
         return obj
 
     def disassemble(self):
@@ -82,7 +82,6 @@ class Submitter(Model):
 class Submission(Model):
     id: str
     submitter_id: str
-    release_date: str
     additional_submitter_ids: List[str]
     submission_date: str
     content: dict
@@ -103,14 +102,13 @@ class Submission(Model):
         )
         obj = Submission(
             id=f"{submitter.id}",  # TODO - FIX w/ Date
-            release_date=submitter.release_date,
             submitter_id=submitter.id,
             additional_submitter_ids=list(filter("id", additional_submitters)),
             submission_date=extract(inp, "@SubmissionDate"),
             content=inp,
         )
-        # TODO
-        # jsonify_content
+        if jsonify_content:
+            obj.content = json.dumps(inp)
         return obj
 
     def disassemble(self):
@@ -184,8 +182,8 @@ class ClinicalAssertion(Model):
             submission=submission,
             content=inp,
         )
-        # TODO
-        # jsonify_content
+        if jsonify_content:
+            obj.content = json.dumps(inp)
         return obj
 
     def disassemble(self):

--- a/clinvar_ingest/model.py
+++ b/clinvar_ingest/model.py
@@ -290,7 +290,9 @@ class Variation(Model):
             ),
             subclass_type=subclass_type,
             allele_id=extract(inp, "@AlleleID"),
-            protein_change=ensure_list(extract(inp, "ProteinChange") or []),
+            protein_change=[
+                pc["$"] for pc in ensure_list(extract(inp, "ProteinChange") or [])
+            ],
             num_copies=int_or_none(extract(inp, "@NumberOfCopies")),
             num_chromosomes=int_or_none(extract(inp, "@NumberOfChromosomes")),
             gene_associations=[],

--- a/clinvar_ingest/model.py
+++ b/clinvar_ingest/model.py
@@ -59,7 +59,7 @@ class Submitter(Model):
 
     @staticmethod
     def from_xml(inp: dict, jsonify_content=True):
-        _logger.info(f"Submitter.from_xml(inp={json.dumps(inp)}, {jsonify_content=})")
+        _logger.debug(f"Submitter.from_xml(inp={json.dumps(inp)}, {jsonify_content=})")
         current_name = extract(inp, "@SubmitterName")
         current_abbrev = extract(inp, "@OrgAbbreviation")
         obj = Submitter(
@@ -97,7 +97,7 @@ class Submission(Model):
         submitter: Submitter = {},
         additional_submitters: list = [Submitter],
     ):
-        _logger.info(
+        _logger.debug(
             f"Submission.from_xml(inp={json.dumps(inp)}, {jsonify_content=}, {submitter=}, "
             f"{additional_submitters=})"
         )
@@ -141,7 +141,7 @@ class ClinicalAssertion(Model):
 
     @staticmethod
     def from_xml(inp: dict, jsonify_content=True):
-        _logger.info(
+        _logger.debug(
             f"ClinicalAssertion.from_xml(inp={json.dumps(inp)}, {jsonify_content=})"
         )
         raw_accession = extract(inp, "ClinVarAccession")
@@ -446,7 +446,7 @@ class Trait(Model):
 
     @staticmethod
     def from_xml(inp: dict, jsonify_content=True) -> Trait:
-        _logger.info(f"Trait.from_xml(inp={json.dumps(inp)})")
+        _logger.debug(f"Trait.from_xml(inp={json.dumps(inp)})")
         id = extract(inp, "@ID")
 
         def make_attr_xrefs(
@@ -742,7 +742,7 @@ class TraitSet(Model):
 
     @staticmethod
     def from_xml(inp: dict, jsonify_content=True):
-        _logger.info(f"TraitSet.from_xml(inp={json.dumps(inp)})")
+        _logger.debug(f"TraitSet.from_xml(inp={json.dumps(inp)})")
         obj = TraitSet(
             id=extract(inp, "@ID"),
             type=extract(inp, "@Type"),

--- a/clinvar_ingest/model.py
+++ b/clinvar_ingest/model.py
@@ -13,14 +13,7 @@ import logging
 from abc import ABCMeta, abstractmethod
 from typing import List, Union
 
-from clinvar_ingest.utils import (
-    ensure_list,
-    extract,
-    extract_in,
-    extract_oneof,
-    flatten1,
-    get,
-)
+from clinvar_ingest.utils import ensure_list, extract, extract_oneof, flatten1, get
 
 _logger = logging.getLogger("clinvar_ingest")
 
@@ -158,7 +151,7 @@ class ClinicalAssertion(Model):
             map(
                 Submitter.from_xml,
                 ensure_list(
-                    extract_in(
+                    extract(
                         raw_accession, "AdditionalSubmitters", "SubmitterDescription"
                     )
                     or []
@@ -288,10 +281,10 @@ class Variation(Model):
                 extract_oneof(inp, "VariantType", "VariationType")[1], "$"
             ),
             subclass_type=subclass_type,
-            allele_id=extract_in(inp, "@AlleleID"),
-            protein_change=ensure_list(extract_in(inp, "ProteinChange") or []),
-            num_copies=int_or_none(extract_in(inp, "@NumberOfCopies")),
-            num_chromosomes=int_or_none(extract_in(inp, "@NumberOfChromosomes")),
+            allele_id=extract(inp, "@AlleleID"),
+            protein_change=ensure_list(extract(inp, "ProteinChange") or []),
+            num_copies=int_or_none(extract(inp, "@NumberOfCopies")),
+            num_chromosomes=int_or_none(extract(inp, "@NumberOfChromosomes")),
             gene_associations=[],
             child_ids=child_ids,
             descendant_ids=descendant_ids,
@@ -794,8 +787,8 @@ class TraitMapping(Model):
             mapping_type=extract(inp, "@MappingType"),
             mapping_value=extract(inp, "@MappingValue"),
             mapping_ref=extract(inp, "@MappingRef"),
-            medgen_name=extract_in(inp, "MedGen", "@Name"),
-            medgen_id=extract_in(inp, "MedGen", "@CUI"),
+            medgen_name=extract(inp, "MedGen", "@Name"),
+            medgen_id=extract(inp, "MedGen", "@CUI"),
         )
 
     def disassemble(self):
@@ -861,23 +854,19 @@ class VariationArchive(Model):
             record_status=extract(extract(inp, "RecordStatus"), "$"),
             species=extract(extract(inp, "Species"), "$"),
             review_status=extract(extract(interp_record, "ReviewStatus"), "$"),
-            interp_type=extract_in(interpretation, "@Type"),
-            interp_description=extract(extract_in(interpretation, "Description"), "$"),
-            interp_explanation=extract_in(
-                extract_in(interpretation, "Explanation"), "$"
-            ),
+            interp_type=extract(interpretation, "@Type"),
+            interp_description=extract(extract(interpretation, "Description"), "$"),
+            interp_explanation=extract(extract(interpretation, "Explanation"), "$"),
             # num_submitters and num_submissions are at top and interp level
-            num_submitters=int_or_none(
-                extract_in(interpretation, "@NumberOfSubmitters")
-            ),
+            num_submitters=int_or_none(extract(interpretation, "@NumberOfSubmitters")),
             num_submissions=int_or_none(
-                extract_in(interpretation, "@NumberOfSubmissions")
+                extract(interpretation, "@NumberOfSubmissions")
             ),
-            interp_date_last_evaluated=extract_in(interpretation, "@DateLastEvaluated"),
+            interp_date_last_evaluated=extract(interpretation, "@DateLastEvaluated"),
             trait_sets=[
                 TraitSet.from_xml(ts, jsonify_content=jsonify_content)
                 for ts in ensure_list(
-                    extract_in(
+                    extract(
                         interpretation,
                         "ConditionList",
                         "TraitSet",
@@ -889,7 +878,7 @@ class VariationArchive(Model):
                 TraitMapping.from_xml(tm, jsonify_content=jsonify_content)
                 for tm in ensure_list(
                     extract(
-                        extract_in(
+                        extract(
                             interp_record,
                             "TraitMapping",
                         ),

--- a/clinvar_ingest/model.py
+++ b/clinvar_ingest/model.py
@@ -22,7 +22,7 @@ from clinvar_ingest.utils import (
     get,
 )
 
-_logger = logging.getLogger(__name__)
+_logger = logging.getLogger("clinvar_ingest")
 
 
 class Model(object, metaclass=ABCMeta):

--- a/clinvar_ingest/model.py
+++ b/clinvar_ingest/model.py
@@ -187,7 +187,17 @@ class ClinicalAssertion(Model):
         return obj
 
     def disassemble(self):
-        yield self
+        self_copy = model_copy(self)
+
+        for subobj in self_copy.submitter.disassemble():
+            yield subobj
+        del self_copy.submitter
+
+        for subobj in self_copy.submission.disassemble():
+            yield subobj
+        del self_copy.submission
+
+        yield self_copy
 
 
 @dataclasses.dataclass

--- a/clinvar_ingest/reader.py
+++ b/clinvar_ingest/reader.py
@@ -2,6 +2,7 @@
 Module for iterating over XML files and calling Model constructors
 on appropriate elements.
 """
+
 import logging
 import xml.etree.ElementTree as ET
 from enum import StrEnum
@@ -11,7 +12,7 @@ import xmltodict
 
 import clinvar_ingest.model as model
 
-_logger = logging.getLogger(__name__)
+_logger = logging.getLogger("clinvar_ingest")
 
 QUEUE_STOP_VALUE = -1
 

--- a/clinvar_ingest/status.py
+++ b/clinvar_ingest/status.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+
+
+class StepName(StrEnum):
+    COPY = "COPY"
+    PARSE = "PARSE"
+    CREATE_EXTERNAL_TABLES = "CREATE_EXTERNAL_TABLES"
+
+
+class StepStatus(StrEnum):
+    STARTED = "STARTED"
+    IN_PROGRESS = "IN_PROGRESS"
+    SUCCEEDED = "SUCCEEDED"
+    FAILED = "FAILED"
+
+
+@dataclass
+class StatusValue(dict):
+    status: StepStatus
+    step: StepName
+    timestamp: datetime
+    message: str = None

--- a/clinvar_ingest/status.py
+++ b/clinvar_ingest/status.py
@@ -1,12 +1,13 @@
 from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
+from typing import Optional, Union
 
 
 class StepName(StrEnum):
-    COPY = "COPY"
-    PARSE = "PARSE"
-    CREATE_EXTERNAL_TABLES = "CREATE_EXTERNAL_TABLES"
+    COPY = "copy"
+    PARSE = "parse"
+    CREATE_EXTERNAL_TABLES = "create_external_tables"
 
 
 class StepStatus(StrEnum):
@@ -21,4 +22,4 @@ class StatusValue(dict):
     status: StepStatus
     step: StepName
     timestamp: datetime
-    message: str = None
+    message: Optional[Union[str, dict]] = None

--- a/clinvar_ingest/utils.py
+++ b/clinvar_ingest/utils.py
@@ -1,3 +1,4 @@
+import time
 from typing import Any, List
 
 
@@ -95,3 +96,29 @@ def flatten1(things: List[List[Any]]) -> List[Any]:
         else:
             outputs.append(thing)
     return outputs
+
+
+def make_progress_logger(logger, fmt: str, max_value: int = 0):
+    def log_progress(current_value, force=False):
+        if getattr(log_progress, "prev_log_time", None) is None:
+            log_progress.prev_log_time = time.time()
+            log_progress.prev_value = 0
+            log_progress.max_value = max_value
+            return
+        now = time.time()
+        if force or now - log_progress.prev_log_time > 5:
+            elapsed = now - log_progress.prev_log_time
+            elapsed_value = current_value - log_progress.prev_value
+            logger.info(
+                fmt.format(
+                    current_value=current_value,
+                    elapsed=elapsed,
+                    elapsed_value=elapsed_value,
+                    max_value=log_progress.max_value,
+                )
+            )
+
+            log_progress.prev_log_time = now
+            log_progress.prev_value = current_value
+
+    return log_progress

--- a/clinvar_ingest/utils.py
+++ b/clinvar_ingest/utils.py
@@ -14,7 +14,7 @@ def extract_oneof(d: dict, *keys: List[Any]) -> Any:
     return None
 
 
-def extract_in(d: dict, *keys: List[Any]) -> Any:
+def extract(d: dict, *keys: List[Any]) -> Any:
     """
     For the path of `keys`, get each value in succession. If any key does not exist,
     return None. If all keys exist, return the value of the last key.
@@ -28,14 +28,6 @@ def extract_in(d: dict, *keys: List[Any]) -> Any:
                 d = d[k]
         else:
             return None
-
-
-def extract(d: dict, key: Any) -> Any:
-    """
-    If `key` is in `d`, remove it and return the value.
-    """
-    if d is not None:
-        return d.pop(key, None)
 
 
 def get(d: dict, *keys: List[Any]) -> Any:

--- a/clinvar_ingest/utils.py
+++ b/clinvar_ingest/utils.py
@@ -98,7 +98,7 @@ def flatten1(things: List[List[Any]]) -> List[Any]:
     return outputs
 
 
-def make_progress_logger(logger, fmt: str, max_value: int = 0):
+def make_progress_logger(logger, fmt: str, max_value: int = 0, interval: int = 10):
     def log_progress(current_value, force=False):
         if getattr(log_progress, "prev_log_time", None) is None:
             log_progress.prev_log_time = time.time()
@@ -106,7 +106,7 @@ def make_progress_logger(logger, fmt: str, max_value: int = 0):
             log_progress.max_value = max_value
             return
         now = time.time()
-        if force or now - log_progress.prev_log_time > 5:
+        if force or now - log_progress.prev_log_time > interval:
             elapsed = now - log_progress.prev_log_time
             elapsed_value = current_value - log_progress.prev_value
             logger.info(

--- a/log_conf.json
+++ b/log_conf.json
@@ -21,6 +21,16 @@
             "handlers": ["default"],
             "propagate": true
         },
+        "clinvar_ingest": {
+            "level": "INFO",
+            "handlers": ["default"],
+            "propagate": true
+        },
+        "clinvar-ingest-workflow": {
+            "level": "INFO",
+            "handlers": ["default"],
+            "propagate": true
+        },
         "uvicorn": {
             "level": "ERROR",
             "handlers": ["default"]

--- a/misc/bin/async-request-handling.py
+++ b/misc/bin/async-request-handling.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+import time
+
+import asyncio
+import multiprocessing
+import logging
+from fastapi import BackgroundTasks, FastAPI, Request
+
+import requests
+
+formatter = logging.Formatter(
+    fmt="%(asctime)s %(levelname)-8s %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+handler = logging.StreamHandler()
+handler.setFormatter(formatter)
+logging.getLogger().addHandler(handler)
+logging.getLogger().setLevel(logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+baseurl = "http://localhost:8000"
+
+
+app = FastAPI(openapi_url="/openapi.json", docs_url="/api")
+
+
+@app.get("/sleep_async_BackgroundTask_busy/{seconds}")
+async def sleep_async_BackgroundTask_busy(
+    request: Request, background_tasks: BackgroundTasks, seconds: int
+):
+    async def task():
+        start = time.time()
+        while time.time() - start < seconds:
+            pass
+
+    background_tasks.add_task(task)
+    return {}
+
+
+@app.get("/sleep_sync_BackgroundTask_busy/{seconds}")
+async def sleep_sync_BackgroundTask_busy(
+    request: Request, background_tasks: BackgroundTasks, seconds: int
+):
+    def task():
+        start = time.time()
+        while time.time() - start < seconds:
+            pass
+
+    background_tasks.add_task(task)
+    return {}
+
+
+@app.get("/async_do_nothing_and_return/{seconds}")
+async def async_do_nothing_and_return(request: Request, seconds: int):
+    return {}
+
+
+def send_request(request_name: str = "sleep_1", seconds=5):
+    logger.info(f"Sending request to {request_name} for {seconds} seconds")
+    response = requests.get(f"{baseurl}/{request_name}/{seconds}", timeout=60)
+    logger.info(f"{request_name} responded with {response.status_code}")
+    logger.info(response.json())
+    return response
+
+
+def scenario1():
+    """
+    async handler, async BackgroundTask, async followup
+    """
+    logger.info("Starting scenario 1")
+    p1 = multiprocessing.Process(
+        target=send_request, args=("sleep_async_BackgroundTask_busy", 30)
+    )
+    p1.start()
+
+    # need to definitively make sure p1 has started before p2. short sleep is enough
+    time.sleep(3)
+
+    p2 = multiprocessing.Process(
+        target=send_request, args=("async_do_nothing_and_return", 0)
+    )
+    p2.start()
+
+    ps = {"p1": p1, "p2": p2}
+    while len(ps.keys()):
+        del_keys = []
+        for p_name, p in ps.items():
+            try:
+                p.join(timeout=0)
+                if not p.is_alive():
+                    logger.info(f"{p_name} joined")
+                    del_keys.append(p_name)
+            except TimeoutError:
+                pass
+        for del_key in del_keys:
+            del ps[del_key]
+
+
+def scenario2():
+    """
+    async handler, sync BackgroundTask, async followup
+    """
+    logger.info("Starting scenario 5")
+    p1 = multiprocessing.Process(
+        target=send_request, args=("sleep_sync_BackgroundTask_busy", 30)
+    )
+    p1.start()
+
+    # need to definitively make sure p1 has started before p2. short sleep is enough
+    time.sleep(3)
+
+    p2 = multiprocessing.Process(
+        target=send_request, args=("async_do_nothing_and_return", 0)
+    )
+    p2.start()
+
+    ps = {"p1": p1, "p2": p2}
+    while len(ps.keys()):
+        del_keys = []
+        for p_name, p in ps.items():
+            try:
+                p.join(timeout=0)
+                if not p.is_alive():
+                    logger.info(f"{p_name} joined")
+                    del_keys.append(p_name)
+            except TimeoutError:
+                pass
+        for del_key in del_keys:
+            del ps[del_key]
+
+
+if __name__ == "__main__":
+    #
+    # Run app with
+    # uvicorn async-request-handling:app --reload
+    #
+    logger.info("Starting client requests")
+    scenario2()
+
+
+# pylint: disable=W0105
+"""
+# Scenario 1 Run Log
+
+Shell 1:
+```
+$ uvicorn async-request-handling:app
+INFO:     Started server process [94215]
+INFO:     Waiting for application startup.
+INFO:     Application startup complete.
+INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
+INFO:     127.0.0.1:60134 - "GET /sleep_async_BackgroundTask_busy/30 HTTP/1.1" 200 OK
+INFO:     127.0.0.1:60139 - "GET /async_do_nothing_and_return/0 HTTP/1.1" 200 OK
+```
+
+Shell 2:
+```
+$ python async-request-handling.py
+2024-01-29 22:28:20 INFO     Starting client requests
+2024-01-29 22:28:20 INFO     Starting scenario 1
+2024-01-29 22:28:21 INFO     Sending request to sleep_async_BackgroundTask_busy for 30 seconds
+2024-01-29 22:28:21 INFO     sleep_async_BackgroundTask_busy responded with 200
+2024-01-29 22:28:21 INFO     {}
+2024-01-29 22:28:23 INFO     p1 joined
+2024-01-29 22:28:24 INFO     Sending request to async_do_nothing_and_return for 0 seconds
+2024-01-29 22:28:51 INFO     async_do_nothing_and_return responded with 200
+2024-01-29 22:28:51 INFO     {}
+2024-01-29 22:28:51 INFO     p2 joined
+```
+
+# Scenario 2 Run Log
+
+Shell 1:
+```
+$ uvicorn async-request-handling:app
+INFO:     Started server process [94890]
+INFO:     Waiting for application startup.
+INFO:     Application startup complete.
+INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
+INFO:     127.0.0.1:60251 - "GET /sleep_sync_BackgroundTask_busy/30 HTTP/1.1" 200 OK
+INFO:     127.0.0.1:60253 - "GET /async_do_nothing_and_return/0 HTTP/1.1" 200 OK
+```
+
+Shell 2:
+```
+python async-request-handling.py
+2024-01-29 22:37:07 INFO     Starting client requests
+2024-01-29 22:37:07 INFO     Starting scenario 5
+2024-01-29 22:37:07 INFO     Sending request to sleep_sync_BackgroundTask_busy for 30 seconds
+2024-01-29 22:37:07 INFO     sleep_sync_BackgroundTask_busy responded with 200
+2024-01-29 22:37:07 INFO     {}
+2024-01-29 22:37:10 INFO     p1 joined
+2024-01-29 22:37:10 INFO     Sending request to async_do_nothing_and_return for 0 seconds
+2024-01-29 22:37:10 INFO     async_do_nothing_and_return responded with 200
+2024-01-29 22:37:10 INFO     {}
+2024-01-29 22:37:10 INFO     p2 joined
+```
+
+# Conclusion
+
+Sending an async task to BackgroundTasks seems to be categorically worse than sending a sync task to BackgroundTasks. The async task will block the main thread, while the sync task will not. This is true even if the async task is followed by an async task, as in scenario 1. The async task will block the main thread. Even if the next request is async, it will not be processed until the first async task is finished. This is not the case with sync tasks. The sync task will not block the main thread, and the next request will be processed immediately. This is true even if the next request is async, as in scenario 2.
+"""

--- a/misc/bin/copy_testing.py
+++ b/misc/bin/copy_testing.py
@@ -12,7 +12,7 @@ logging.basicConfig(
     format="%(asctime)s.%(msecs)03d - %(levelname)s - %(name)s - %(funcName)s - %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S",
 )
-logger = logging.getLogger("urlopen.ipynb")
+logger = logging.getLogger("copy_testing.ipynb")
 
 
 # This is the url for a ClinVarVariationRelease xml file:

--- a/misc/bin/copy_testing.py
+++ b/misc/bin/copy_testing.py
@@ -1,0 +1,37 @@
+import logging
+from typing import Iterator
+import urllib.request
+import requests
+
+from google.cloud import storage
+
+from clinvar_ingest.cloud.gcs import blob_writer, http_upload_urllib
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s.%(msecs)03d - %(levelname)s - %(name)s - %(funcName)s - %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger("urlopen.ipynb")
+
+
+# This is the url for a ClinVarVariationRelease xml file:
+file_baseurl = "https://ftp.ncbi.nlm.nih.gov/pub/clinvar/xml/VCV_xml_old_format/"
+file_name = "ClinVarVariationRelease_2024-02.xml.gz"
+file_url = file_baseurl + file_name
+
+local_file = "./ClinVarVariationRelease_2024-02.xml.gz"
+
+expected_file_size = 3298023159
+
+storage_client = storage.Client()
+
+bucket_path = "kyle-test"
+
+http_upload_urllib(
+    http_uri=file_url,
+    blob_uri=f"gs://clinvar-ingest/{bucket_path}/{file_name}",
+    file_size=expected_file_size,
+    client=storage_client,
+    chunk_size=8 * 1024 * 1024,
+)

--- a/misc/bin/copy_testing.py
+++ b/misc/bin/copy_testing.py
@@ -5,7 +5,12 @@ import requests
 
 from google.cloud import storage
 
-from clinvar_ingest.cloud.gcs import blob_writer, http_upload_urllib
+from clinvar_ingest.cloud.gcs import (
+    blob_writer,
+    http_upload,
+    http_download_curl,
+    http_download_requests,
+)
 
 logging.basicConfig(
     level=logging.INFO,
@@ -28,10 +33,18 @@ storage_client = storage.Client()
 
 bucket_path = "kyle-test"
 
-http_upload_urllib(
-    http_uri=file_url,
-    blob_uri=f"gs://clinvar-ingest/{bucket_path}/{file_name}",
-    file_size=expected_file_size,
-    client=storage_client,
-    chunk_size=8 * 1024 * 1024,
+# http_upload(
+#     http_uri=file_url,
+#     blob_uri=f"gs://clinvar-ingest/{bucket_path}/{file_name}",
+#     file_size=expected_file_size,
+#     client=storage_client,
+#     chunk_size=8 * 1024 * 1024,
+# )
+
+http_download_curl(
+    http_uri=file_url, local_path=local_file, file_size=expected_file_size
 )
+
+# http_download_requests(
+#     http_uri=file_url, local_path=local_file, file_size=expected_file_size
+# )

--- a/misc/bin/deploy-job.sh
+++ b/misc/bin/deploy-job.sh
@@ -61,7 +61,7 @@ gcloud builds submit \
 
 gcloud run jobs create $instance_name \
     --cpu=2 \
-    --memory=2Gi \
+    --memory=8Gi \
     --task-timeout=10h \
     --image=$image \
     --region=$region \

--- a/misc/bin/deploy-job.sh
+++ b/misc/bin/deploy-job.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+branch=$(git rev-parse --abbrev-ref HEAD)
+commit=$(git rev-parse HEAD)
+echo "Branch: $branch"
+echo "Commit: $commit"
+
+instance_name="clinvar-ingest-${branch}"
+clinvar_ingest_bucket="clinvar-ingest"
+
+region="us-central1"
+# project=$(gcloud config get project)
+image_tag=workflow-py-$commit
+image=gcr.io/clingen-dev/clinvar-ingest:$image_tag
+pipeline_service_account=clinvar-ingest-pipeline@clingen-dev.iam.gserviceaccount.com
+deployment_service_account=clinvar-ingest-deployment@clingen-dev.iam.gserviceaccount.com
+clinvar_ftp_url="https://raw.githubusercontent.com"
+
+if gcloud run jobs list --region us-central1 | awk '{print $2}' | grep "^$instance_name$"  ; then
+    echo "Cloud Run Job $instance_name already exists"
+    echo "Deleting Cloud Run Service"
+    gcloud run jobs delete $instance_name --region $region
+fi
+
+
+# Build the image
+cloudbuild=.cloudbuild/workflow-py.docker.cloudbuild.yaml
+
+tar --no-xattrs -c \
+    clinvar_ingest \
+    test \
+    misc \
+    Dockerfile \
+    Dockerfile-workflow-py \
+    pyproject.toml \
+    log_conf.json \
+    .cloudbuild \
+    | gzip --fast > archive.tar.gz
+
+gcloud builds submit \
+    --substitutions="COMMIT_SHA=${image_tag}" \
+    --config .cloudbuild/workflow-py.docker.cloudbuild.yaml \
+    --gcs-log-dir=gs://${clinvar_ingest_bucket}/build/logs \
+    archive.tar.gz
+
+# gcloud run jobs create [JOB] --image=IMAGE [--args=[ARG,...]]
+#     [--binary-authorization=POLICY] [--breakglass=JUSTIFICATION]
+#     [--command=[COMMAND,...]] [--cpu=CPU] [--key=KEY]
+#     [--labels=[KEY=VALUE,...]] [--max-retries=MAX_RETRIES]
+#     [--memory=MEMORY] [--parallelism=PARALLELISM] [--region=REGION]
+#     [--service-account=SERVICE_ACCOUNT]
+#     [--set-cloudsql-instances=[CLOUDSQL-INSTANCES,...]]
+#     [--set-secrets=[KEY=SECRET_NAME:SECRET_VERSION,...]]
+#     [--task-timeout=TASK_TIMEOUT] [--tasks=TASKS; default=1]
+#     [--vpc-connector=VPC_CONNECTOR] [--vpc-egress=VPC_EGRESS]
+#     [--async | --execute-now --wait]
+#     [--env-vars-file=FILE_PATH | --set-env-vars=[KEY=VALUE,...]]
+#     [GCLOUD_WIDE_FLAG ...]
+
+gcloud run jobs create $instance_name \
+    --cpu=2 \
+    --memory=2Gi \
+    --task-timeout=10h \
+    --image=$image \
+    --region=$region \
+    --service-account=$pipeline_service_account \
+    --set-env-vars=CLINVAR_INGEST_BUCKET=$clinvar_ingest_bucket

--- a/misc/bin/execute-job.sh
+++ b/misc/bin/execute-job.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -xeuo pipefail
+
+branch=$(git rev-parse --abbrev-ref HEAD)
+commit=$(git rev-parse HEAD)
+echo "Branch: $branch"
+echo "Commit: $commit"
+
+job_name="clinvar-ingest-${branch}"
+region="us-central1"
+
+# Global Variables
+CLINVAR_INGEST_BUCKET="clinvar-ingest"
+
+
+# Larger input
+host="https://ftp.ncbi.nlm.nih.gov"
+directory="/pub/clinvar/xml/VCV_xml_old_format"
+name="ClinVarVariationRelease_2024-02.xml.gz"
+size=3298023159
+last_modified="2024-01-07T15:47:16"
+released="2024-02-01T15:47:16"
+release_date="2024-02-01"
+
+
+# Smaller input
+# host=https://raw.githubusercontent.com
+# directory=/clingen-data-model/clinvar-ingest/main/test/data
+# name=OriginalTestDataSet.xml.gz
+# size=46719
+# last_modified=2023-10-07T15:47:16
+# released=2023-10-07T15:47:16
+# release_date=2023-10-07
+
+
+env_vars="CLINVAR_INGEST_BUCKET=$CLINVAR_INGEST_BUCKET"
+env_vars="$env_vars,host=$host"
+env_vars="$env_vars,directory=$directory"
+env_vars="$env_vars,name=$name"
+env_vars="$env_vars,size=$size"
+env_vars="$env_vars,last_modified=$last_modified"
+env_vars="$env_vars,released=$released"
+env_vars="$env_vars,release_date=$release_date"
+
+
+gcloud run jobs execute $job_name \
+    --region $region \
+    --update-env-vars=$env_vars

--- a/misc/bin/partition_testing.py
+++ b/misc/bin/partition_testing.py
@@ -1,0 +1,209 @@
+"""
+Last run:
+python partition_testing.py  984.58s user 5.19s system 99% cpu 16:37.82 total
+
+16 minutes isn't too bad. Within the 60 minute max range. Then if we can split the parses
+into 10 parallel jobs, it could speed up the entire workflow, and get the parse step
+well under 60 minutes as well, meaning we don' need the async step completion checks,
+which is causing failures by having a container without active requests be terminated.
+BackgroundTasks are not active requests and make the container look idle.
+"""
+
+import gzip
+import logging
+from pathlib import Path
+import time
+from typing import Any, Iterator, TextIO, Tuple
+import urllib.request
+import requests
+import xml.etree.ElementTree as ET
+
+from google.cloud import storage
+import xmltodict
+
+from clinvar_ingest.cloud.gcs import (
+    blob_writer,
+    http_upload,
+    http_download_curl,
+    http_download_requests,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s.%(msecs)03d - %(levelname)s - %(name)s - %(funcName)s - %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+_logger = logging.getLogger("copy_testing.ipynb")
+
+
+# This is the url for a ClinVarVariationRelease xml file:
+file_baseurl = "https://ftp.ncbi.nlm.nih.gov/pub/clinvar/xml/VCV_xml_old_format/"
+file_name = "ClinVarVariationRelease_2024-02.xml.gz"
+file_url = file_baseurl + file_name
+
+local_file = "./ClinVarVariationRelease_2024-02.xml.gz"
+
+expected_file_size = 3298023159
+
+# storage_client = storage.Client()
+
+bucket_path = "kyle-test"
+
+
+file_path = "/Users/kferrite/dev/data/ClinVarVariationRelease_2024-0107.xml.gz"
+
+
+# Parse this file path as xml using ElementTree, element b
+
+
+def _handle_text_nodes(path, key, value) -> Tuple[Any, Any]:
+    """
+    Takes a path, key, value, returns a tuple of new (key, value)
+
+    If the value looks like an XML text node, put it in a key "$".
+
+    Used as a postprocessor for xmltodict.parse.
+    """
+    if isinstance(value, str) and not key.startswith("@"):
+        if key == "#text":
+            return ("$", value)
+        else:
+            return (key, {"$": value})
+    return (key, value)
+
+
+def _parse_xml_document(doc_str: str):
+    """
+    Reads an XML document from a string.
+    """
+    return xmltodict.parse(doc_str, postprocessor=_handle_text_nodes)
+
+
+def split_clinvar_xml(
+    reader: TextIO,
+    output_dir: Path,
+    partitions=10,
+) -> Iterator[ET.Element]:
+    """
+    Generator function that reads a ClinVar Variation XML file and outputs objects.
+    Accepts `reader` as a readable TextIO/BytesIO object, or a filename.
+    """
+    ROOT_ELEMENT = "ClinVarVariationRelease"
+    N = int(1e6)
+    ct = 0
+    output_paths = [output_dir / f"part_{i}.xml.gz" for i in range(partitions)]
+    output_files = [gzip.open(p, "wb", compresslevel=1) for p in output_paths]
+
+    def a_file():
+        if getattr(a_file, "i", None) is None:
+            a_file.i = 0
+        some_f = output_files[a_file.i]
+        a_file.i = (a_file.i + 1) % len(output_files)
+        return some_f
+
+    prior_ct = 0
+    prior_log_ts = time.time()
+
+    try:
+
+        # Write XML roots to output files
+        # for f in output_files:
+        #     f.write('<?xml version="1.0"?>\n')
+        #     f.write("<ClinVarVariation>\n")
+
+        unclosed = 0
+        for event, elem in ET.iterparse(reader, events=["start", "end"]):
+            # https://docs.python.org/3/library/xml.etree.elementtree.html#element-objects
+            # tag text attrib
+
+            # Sanity checks to make sure we only parse at the correct depth.
+            # For depth=1 (first level inside the root, unclosed should == 1)
+            # ET sends an end event for self-closed tags like e.g. <br/>, so this should work.
+            if event == "start":
+                unclosed += 1
+            elif event == "end":
+                unclosed -= 1
+            else:
+                raise ValueError(
+                    f"Unexpected event: {event}. Element: {ET.tostring(elem)}"
+                )
+
+            if event == "start" and elem.tag == ROOT_ELEMENT:
+
+                # Write XML root elements to output files
+                for f_out in output_files:
+                    # f.write('<?xml version="1.0"?>\n')
+                    f_out.write(ET.tostring(elem))
+
+                release_date = elem.attrib["ReleaseDate"]
+                _logger.info(f"Parsing release date: {release_date}")
+
+            elif event == "end" and elem.tag == "VariationArchive":
+
+                if unclosed != 1:
+                    _logger.warning(
+                        f"Found a VariationArchive at a depth other than 1:"
+                        f" {unclosed}, element: {ET.tostring(elem)}"
+                    )
+                else:
+                    # elem_s = element_to_string(elem)
+                    a_file().write(ET.tostring(elem))
+
+                elem.clear()
+
+                ct = ct + 1
+                if ct >= N:
+                    break
+
+            # log progress
+            now = time.time()
+            elapsed = now - prior_log_ts
+            if elapsed > 10:
+                elapsed_ct = ct - prior_ct
+                _logger.info(
+                    f"Processed {elapsed_ct} elements in {elapsed:.2f} seconds."
+                )
+                prior_log_ts = now
+                prior_ct = ct
+
+        # Return written files
+        return output_paths
+    except Exception as e:
+        _logger.error(f"Error occurred: {e}")
+        raise e
+    finally:
+        for _f in output_files:
+            _f.write(f"</{ROOT_ELEMENT}>\n".encode("utf-8"))
+            _f.close()
+
+
+import xml.etree.ElementTree as ET
+
+
+def write_element(file, element):
+    file.write(ET.tostring(element, encoding="unicode"))
+
+
+# with open("output.xml", "w") as f:
+#     f.write('<?xml version="1.0"?>\n')  # Write the XML declaration
+
+#     root = ET.Element("root")
+#     write_element(f, root)  # Write the root element start tag
+
+#     for i in range(10):  # Replace with your actual data
+#         child = ET.Element("child")
+#         child.text = f"This is child {i}"
+#         write_element(f, child)  # Write the child element
+
+#     f.write("</root>\n")  # Write the root element end tag
+
+output_dir = Path("/Users/kferrite/dev/clinvar-ingest/misc/bin/clinvar_split")
+if not output_dir.exists():
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+with gzip.open(file_path, "rb") as f:
+    output_paths = split_clinvar_xml(
+        f,
+        output_dir=output_dir,
+        partitions=10,
+    )

--- a/misc/bin/poll-workflow-test.py
+++ b/misc/bin/poll-workflow-test.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+import time
+
+import requests
+
+# pylint: disable=W0105
+"""
+Output example:
+Workflow Execution ID: poll-test_2024-01-29T05:32:15.087284
+{'detail': 'Could not find status file for step COPY with status STARTED in bucket <Bucket: clinvar-ingest> and file prefix executions/poll-test_2024-01-29T05:32:15.087284'}
+201
+{'workflow_execution_id': 'poll-test_2024-01-29T05:32:15.087284', 'step_name': 'COPY', 'timestamp': '2024-01-29T05:29:49.732983', 'step_status': 'STARTED', 'message': None}
+Status Response: {'workflow_execution_id': 'poll-test_2024-01-29T05:32:15.087284', 'step_name': 'COPY', 'step_status': 'SUCCEEDED', 'timestamp': '2024-01-29T05:29:49.732983', 'message': None}
+Step succeeded
+"""
+
+
+wf_input = {
+    "Directory": "/clingen-data-model/clinvar-ingest/main/test/data",
+    "Host": "https://raw.githubusercontent.com",
+    "Last Modified": "2023-10-07 15:47:16",
+    "Name": "OriginalTestDataSet.xml.gz",
+    "Release Date": "2023-10-07",
+    "Released": "2023-10-07 15:47:16",
+    "Size": 46719,
+}
+
+wf_exec_id_seed = "poll-test"
+baseurl = "http://localhost:8000"
+wf_init_resp = requests.post(
+    f"{baseurl}/create_workflow_execution_id/{wf_exec_id_seed}", timeout=60
+)
+assert wf_init_resp.status_code == 201
+execution_id = wf_init_resp.json()["workflow_execution_id"]
+print(f"Workflow Execution ID: {execution_id}")
+
+# # execution id has been created but no steps have been started, assert that the status check a 404
+# status_resp = requests.get(f"{baseurl}/step_status/{execution_id}/COPY", timeout=60)
+# print(status_resp.json())
+# assert status_resp.status_code == 404
+
+
+# Run /copy step that writes a STARTED file, returns immediately,
+# while running something and writing a SUCCEED file asynchronously
+step1_resp = requests.post(f"{baseurl}/copy/{execution_id}", json=wf_input, timeout=60)
+print(step1_resp.status_code)
+print(step1_resp.json())
+assert step1_resp.status_code == 201
+step1_resp_json = step1_resp.json()
+
+# poll for completion
+while True:
+    print("Sending status check request...")
+    status_resp = requests.get(f"{baseurl}/step_status/{execution_id}/copy", timeout=60)
+    assert status_resp.status_code == 200
+    status_resp_json = status_resp.json()
+    print(f"Status Response: {status_resp_json}")
+    if status_resp_json["step_status"] == "SUCCEEDED":
+        print("Step succeeded")
+        break
+    elif status_resp_json["step_status"] == "FAILED":
+        raise RuntimeError(f"Step failed: {status_resp_json}")
+    time.sleep(5)

--- a/misc/bin/poll-workflow-test.py
+++ b/misc/bin/poll-workflow-test.py
@@ -25,8 +25,10 @@ wf_input = {
     "Size": 46719,
 }
 
-wf_exec_id_seed = "poll-test"
+wf_exec_id_seed = "poll_test"
 baseurl = "http://localhost:8000"
+# baseurl =
+
 wf_init_resp = requests.post(
     f"{baseurl}/create_workflow_execution_id/{wf_exec_id_seed}", timeout=60
 )

--- a/misc/bin/poll-workflow-test.py
+++ b/misc/bin/poll-workflow-test.py
@@ -60,4 +60,4 @@ while True:
         break
     elif status_resp_json["step_status"] == "FAILED":
         raise RuntimeError(f"Step failed: {status_resp_json}")
-    time.sleep(5)
+    time.sleep(1)

--- a/misc/bin/poll-workflow-test.py
+++ b/misc/bin/poll-workflow-test.py
@@ -3,6 +3,7 @@ import time
 import json
 import requests
 
+
 # pylint: disable=W0105
 """
 Output example:
@@ -15,15 +16,26 @@ Step succeeded
 """
 
 
+# wf_input = {
+#     "Directory": "/clingen-data-model/clinvar-ingest/main/test/data",
+#     "Host": "https://raw.githubusercontent.com",
+#     "Last Modified": "2023-10-07 15:47:16",
+#     "Name": "OriginalTestDataSet.xml.gz",
+#     "Release Date": "2023-10-07",
+#     "Released": "2023-10-07 15:47:16",
+#     "Size": 46719,
+# }
+
 wf_input = {
-    "Directory": "/clingen-data-model/clinvar-ingest/main/test/data",
-    "Host": "https://raw.githubusercontent.com",
-    "Last Modified": "2023-10-07 15:47:16",
-    "Name": "OriginalTestDataSet.xml.gz",
-    "Release Date": "2023-10-07",
-    "Released": "2023-10-07 15:47:16",
-    "Size": 46719,
+    "Directory": "/pub/clinvar/xml/VCV_xml_old_format",
+    "Host": "https://ftp.ncbi.nlm.nih.gov/",
+    "Last Modified": "2024-01-07 15:47:16",
+    "Name": "ClinVarVariationRelease_2024-02.xml.gz",
+    "Release Date": "2024-02-01",
+    "Released": "2024-02-01 15:47:16",
+    "Size": 3298023159,
 }
+
 
 wf_exec_id_seed = "poll_test"
 baseurl = "http://localhost:8000"

--- a/misc/bin/poll-workflow-test.py
+++ b/misc/bin/poll-workflow-test.py
@@ -98,6 +98,7 @@ while True:
 cet_input = json.loads(status_resp_json["message"])
 cet_input["source_table_paths"] = cet_input["parsed_files"]
 del cet_input["parsed_files"]
+cet_input["destination_dataset"] = execution_id
 print(f"{cet_input=}")
 cet_step_response = requests.post(
     f"{baseurl}/create_external_tables/{execution_id}", json=cet_input, timeout=60

--- a/misc/bin/workflow.py
+++ b/misc/bin/workflow.py
@@ -77,10 +77,7 @@ def _get_gcs_client() -> GCSClient:
 
 
 ################################################################
-### Main code
-# TODO remove these injections
-# os.environ["WF_INPUT"] = json.dumps(wf_input)
-# os.environ["CLINVAR_INGEST_BUCKET"] = "clinvar-ingest"
+### Initialization code
 
 # Main env for the codebase
 env = get_env()
@@ -96,8 +93,7 @@ _logger.info(f"Workflow Execution ID: {workflow_execution_id}")
 
 
 ################################################################
-# Run /copy step that writes a STARTED file, returns immediately,
-# while running something and writing a SUCCEED file asynchronously
+# Run copy step. Copies a source XML file from an HTTP/FTP server to GCS
 
 
 def copy(payload: ClinvarFTPWatcherRequest) -> CopyResponse:
@@ -139,7 +135,7 @@ _logger.info(f"Copy response: {copy_response.model_dump_json()}")
 
 
 ################################################################
-# Run /parse step that writes a STARTED file, returns immediately
+# Reads an XML file from GCS, parses it, and writes the parsed data to GCS
 
 
 def parse(payload: ParseRequest) -> ParseResponse:
@@ -162,7 +158,7 @@ _logger.info(f"Parse response: {parse_response.model_dump_json}")
 
 
 ################################################################
-# Run /create_external_tables step that writes a STARTED file, returns immediately
+# Creates external tables in BigQuery from the parsed data in GCS
 
 
 def create_external_tables(
@@ -195,4 +191,7 @@ create_external_tables_response = create_external_tables(
 _logger.info(
     f"Create External Tables response: {create_external_tables_response.model_dump_json()}"
 )
+
+
+################################################################
 _logger.info("Workflow succeeded")

--- a/misc/bin/workflow.py
+++ b/misc/bin/workflow.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+from datetime import datetime
+from pathlib import PurePosixPath
+import os
+import logging
+
+from google.cloud.storage import Client as GCSClient
+from google.cloud import bigquery
+
+from clinvar_ingest.cloud.bigquery.create_tables import run_create_external_tables
+from clinvar_ingest.config import get_env
+from clinvar_ingest.api.model.requests import (
+    ClinvarFTPWatcherRequest,
+    CopyResponse,
+    CreateExternalTablesRequest,
+    CreateExternalTablesResponse,
+    ParseRequest,
+    ParseResponse,
+)
+from clinvar_ingest.cloud.gcs import copy_file_to_bucket, http_download_requests
+from clinvar_ingest.parse import parse_and_write_files
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s.%(msecs)03d - %(levelname)s - %(name)s - %(funcName)s - %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+_logger = logging.getLogger("clinvar-ingest-workflow")
+
+
+wf_input = {
+    "Directory": "/clingen-data-model/clinvar-ingest/main/test/data",
+    "Host": "https://raw.githubusercontent.com",
+    "Last Modified": "2023-10-07 15:47:16",
+    "Name": "OriginalTestDataSet.xml.gz",
+    "Release Date": "2023-10-07",
+    "Released": "2023-10-07 15:47:16",
+    "Size": 46719,
+}
+
+# wf_input = {
+#     "Host": "https://ftp.ncbi.nlm.nih.gov",
+#     "Directory": "/pub/clinvar/xml/clinvar_variation/weekly_release",
+#     "Name": "ClinVarVariationRelease_2023-1104.xml.gz",
+#     "Size": 3160398711,
+#     "Released": "2023-11-05 15:47:16",
+#     "Last Modified": "2023-11-05 15:47:16",
+#     "Release Date": "2023-11-04",
+# }
+
+# wf_input = {
+#     "Directory": "/pub/clinvar/xml/VCV_xml_old_format",
+#     "Host": "https://ftp.ncbi.nlm.nih.gov/",
+#     "Last Modified": "2024-01-07 15:47:16",
+#     "Name": "ClinVarVariationRelease_2024-02.xml.gz",
+#     "Release Date": "2024-02-01",
+#     "Released": "2024-02-01 15:47:16",
+#     "Size": 3298023159,
+# }
+
+
+def create_execution_id(seed: str):
+    timestamp = (
+        datetime.utcnow()
+        .isoformat()
+        .replace(":", "")
+        .replace(".", "")
+        .replace("-", "_")
+    )
+    return f"{seed}_{timestamp}"
+
+
+def _get_gcs_client() -> GCSClient:
+    if getattr(_get_gcs_client, "client", None) is None:
+        setattr(_get_gcs_client, "client", GCSClient())
+    return getattr(_get_gcs_client, "client")
+
+
+################################################################
+### Main code
+# TODO remove these injections
+# os.environ["WF_INPUT"] = json.dumps(wf_input)
+# os.environ["CLINVAR_INGEST_BUCKET"] = "clinvar-ingest"
+
+# Main env for the codebase
+env = get_env()
+
+# Workflow specific input (which also comes from the env)
+wf_input = ClinvarFTPWatcherRequest(**os.environ)
+
+
+workflow_execution_id = create_execution_id(
+    wf_input.release_date.isoformat().replace("-", "_")
+)
+_logger.info(f"Workflow Execution ID: {workflow_execution_id}")
+
+
+################################################################
+# Run /copy step that writes a STARTED file, returns immediately,
+# while running something and writing a SUCCEED file asynchronously
+
+
+def copy(payload: ClinvarFTPWatcherRequest) -> CopyResponse:
+    _logger.info(f"copy payload: {payload.model_dump_json()}")
+    ftp_base = str(payload.host).strip("/")
+    ftp_dir = PurePosixPath(payload.directory)
+    ftp_file = PurePosixPath(payload.name)
+    ftp_file_size = payload.size
+    ftp_path = f"{ftp_base}/{ftp_dir.relative_to(ftp_dir.anchor) / ftp_file}"
+
+    gcs_base = (
+        f"gs://{env.bucket_name}/{env.executions_output_prefix}/{workflow_execution_id}"
+    )
+    gcs_dir = PurePosixPath(env.bucket_staging_prefix)
+    gcs_file = PurePosixPath(payload.name)
+    gcs_path = f"{gcs_base}/{gcs_dir.relative_to(gcs_dir.anchor) / gcs_file}"
+
+    _logger.info(f"Copying {ftp_path} to {gcs_path}")
+
+    # Download file
+    local_path = http_download_requests(
+        http_uri=ftp_path,
+        local_path=ftp_file,  # Just the file name, relative to current working directory
+        file_size=ftp_file_size,
+    )
+    _logger.info(f"Downloaded {ftp_path} to {local_path}")
+
+    # Upload file to GCS
+    client = _get_gcs_client()
+    copy_file_to_bucket(
+        local_file_uri=local_path, remote_blob_uri=gcs_path, client=client
+    )
+    _logger.info(f"Uploaded {local_path} to {gcs_path}")
+    return CopyResponse(ftp_path=ftp_path, gcs_path=gcs_path)
+
+
+copy_response = copy(wf_input)
+_logger.info(f"Copy response: {copy_response.model_dump_json()}")
+
+
+################################################################
+# Run /parse step that writes a STARTED file, returns immediately
+
+
+def parse(payload: ParseRequest) -> ParseResponse:
+    _logger.info(f"parse payload: {payload.model_dump_json()}")
+    execution_prefix = f"{env.executions_output_prefix}/{workflow_execution_id}"
+    parse_output_path = (
+        f"gs://{env.bucket_name}/{execution_prefix}/{env.parse_output_prefix}"
+    )
+    output_files = parse_and_write_files(
+        payload.input_path,
+        parse_output_path,
+        disassemble=payload.disassemble,
+        jsonify_content=payload.jsonify_content,
+    )
+    return ParseResponse(parsed_files=output_files)
+
+
+parse_response = parse(ParseRequest(input_path=copy_response.gcs_path))
+_logger.info(f"Parse response: {parse_response.model_dump_json}")
+
+
+################################################################
+# Run /create_external_tables step that writes a STARTED file, returns immediately
+
+
+def create_external_tables(
+    payload: CreateExternalTablesRequest,
+) -> CreateExternalTablesResponse:
+    _logger.info(f"create_external_tables payload: {payload.model_dump_json()}")
+    tables_created = run_create_external_tables(payload)
+    for table_name, table in tables_created.items():
+        table: bigquery.Table = table
+        _logger.info(
+            "Created table %s as %s:%s.%s",
+            table_name,
+            table.project,
+            table.dataset_id,
+            table.table_id,
+        )
+    entity_type_table_ids = {
+        entity_type: table.full_table_id
+        for entity_type, table in tables_created.items()
+    }
+    return CreateExternalTablesResponse(root=entity_type_table_ids)
+
+
+create_external_tables_response = create_external_tables(
+    CreateExternalTablesRequest(
+        destination_dataset=workflow_execution_id,
+        source_table_paths=parse_response.parsed_files,
+    )
+)
+_logger.info(
+    f"Create External Tables response: {create_external_tables_response.model_dump_json()}"
+)
+_logger.info("Workflow succeeded")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "google-cloud-storage~=2.13.0",
     "fastapi~=0.104.1",
     "uvicorn~=0.24.0",
+    "requests~=2.31.0"
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ include = ["clinvar_ingest*"]
 
 [tool.setuptools.package-data]
 "clinvar_ingest" = ["*.json", ".*.env"]
+"clinvar_ingest.cloud.bigquery.bq_json_schemas" = ["*.json"]
 
 [tool.isort]
 profile = "black"

--- a/test/api/test_main.py
+++ b/test/api/test_main.py
@@ -1,11 +1,14 @@
 import json
 import logging.config
+from datetime import datetime
 from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
 
 from clinvar_ingest.api.main import app
+from clinvar_ingest.api.model.requests import StepStartedResponse
+from clinvar_ingest.status import StatusValue, StepName, StepStatus
 
 
 @pytest.fixture
@@ -28,12 +31,28 @@ def test_status_check(log_conf, caplog) -> None:
         assert "elapsed_ms" in caplog.records[2].msg
 
 
+@pytest.mark.integration
 def test_copy_endpoint_success(log_conf, env_config, caplog) -> None:
+    started_status_value = StatusValue(
+        StepStatus.STARTED, StepName.COPY, datetime.utcnow().isoformat()
+    )
+    succeeded_status_value = StatusValue(
+        StepStatus.SUCCEEDED, StepName.COPY, datetime.utcnow().isoformat()
+    )
     with (
         patch("clinvar_ingest.api.main.http_upload_urllib", return_value=None),
         patch("clinvar_ingest.api.main._get_gcs_client", return_value="not a client"),
+        patch(
+            "clinvar_ingest.api.main.write_status_file",
+            return_value=started_status_value,
+        ),
+        patch(
+            "clinvar_ingest.api.main.get_status_file",
+            return_value=succeeded_status_value,
+        ),
         TestClient(app) as client,
     ):
+        wf_execution_id = "test-execution-id"
         body = {
             "Name": "ClinVarVariationRelease_2023-1104.xml.gz",
             "Size": 10,
@@ -44,21 +63,27 @@ def test_copy_endpoint_success(log_conf, env_config, caplog) -> None:
             "Release Date": "2023-12-04",
         }
         response = client.post(
-            "/copy",
+            f"/copy/{wf_execution_id}",
             json=body,
         )
         assert response.status_code == 201
-        assert response.json() == {
-            "ftp_path": f"{env_config.clinvar_ftp_base_url}/pub/clinvar/xml/clinvar_variation/weekly_release/ClinVarVariationRelease_2023-1104.xml.gz",
-            "gcs_path": f"gs://{env_config.bucket_name}/{env_config.bucket_staging_prefix}/ClinVarVariationRelease_2023-1104.xml.gz",
-        }
+
+        expected_started_response = StepStartedResponse(
+            workflow_execution_id=wf_execution_id,
+            step_name=StepName.COPY,
+            timestamp=datetime.utcnow(),
+            step_status=StepStatus.STARTED,
+        )
+        actual_started_response = StepStartedResponse(**response.json())
+        actual_started_response.timestamp = expected_started_response.timestamp
+        assert expected_started_response == actual_started_response
 
         body["Released"] = "2022-12-05"
         response = client.post(
-            "/copy",
+            f"/copy/{wf_execution_id}",
             json=body,
         )
         assert response.status_code == 422
         assert "Input should be a valid datetime" in response.text
-        assert len(caplog.records) == 6
-        assert "status_code=422" in caplog.records[5].msg
+        assert len(caplog.records) == 9
+        # assert "status_code=422" in caplog.records[5].msg

--- a/test/api/test_main.py
+++ b/test/api/test_main.py
@@ -40,7 +40,8 @@ def test_copy_endpoint_success(log_conf, env_config, caplog) -> None:
         StepStatus.SUCCEEDED, StepName.COPY, datetime.utcnow().isoformat()
     )
     with (
-        patch("clinvar_ingest.api.main.http_upload_urllib", return_value=None),
+        patch("clinvar_ingest.api.main.http_download_curl", return_value=None),
+        patch("clinvar_ingest.api.main.copy_file_to_bucket", return_value=None),
         patch("clinvar_ingest.api.main._get_gcs_client", return_value="not a client"),
         patch(
             "clinvar_ingest.api.main.write_status_file",

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -2,6 +2,8 @@ from clinvar_ingest.model import (
     ClinicalAssertion,
     Gene,
     GeneAssociation,
+    Submission,
+    Submitter,
     Trait,
     TraitSet,
     Variation,
@@ -20,15 +22,19 @@ def test_read_original_clinvar_variation_2():
         objects = list(read_clinvar_xml(f))
 
     # gene, gene_association, variation, variation_archive
-    assert 8 == len(objects)
+    assert 12 == len(objects)
     assert isinstance(objects[0], Gene)
     assert isinstance(objects[1], GeneAssociation)
     assert isinstance(objects[2], Variation)
     assert isinstance(objects[3], Trait)
     assert isinstance(objects[4], TraitSet)
-    assert isinstance(objects[5], ClinicalAssertion)
-    assert isinstance(objects[6], ClinicalAssertion)
-    assert isinstance(objects[7], VariationArchive)
+    assert isinstance(objects[5], Submitter)
+    assert isinstance(objects[6], Submission)
+    assert isinstance(objects[7], ClinicalAssertion)
+    assert isinstance(objects[8], Submitter)
+    assert isinstance(objects[9], Submission)
+    assert isinstance(objects[10], ClinicalAssertion)
+    assert isinstance(objects[11], VariationArchive)
 
     variation = objects[2]
 
@@ -56,21 +62,21 @@ def test_read_original_clinvar_variation_2():
     assert gene_association.variation_id == "2"
 
     # SCVs - TODO build out further
-    scv = objects[5]
+    scv = objects[7]
     assert scv.assertion_id == "20155"
-    submitter = scv.submitter
+    submitter = objects[5]
     assert submitter.id == "3"
     assert submitter.current_name == "OMIM"
-    submission = scv.submission
+    submission = objects[6]
     assert submission.id == "3"
     assert submission.submission_date == "2017-01-26"
 
-    scv = objects[6]
+    scv = objects[10]
     assert scv.assertion_id == "2865972"
-    submitter = scv.submitter
+    submitter = objects[8]
     assert submitter.id == "507826"
     assert submitter.current_name == "Paris Brain Institute, Inserm - ICM"
-    submission = scv.submission
+    submission = objects[9]
     assert submission.id == "507826"
     assert submission.submission_date == "2020-11-14"
 
@@ -84,7 +90,7 @@ def test_read_original_clinvar_variation_634266():
     with open(filename) as f:
         objects = list(read_clinvar_xml(f))
 
-    assert 14 == len(objects)
+    assert 22 == len(objects)
     assert isinstance(objects[0], Variation)
     assert isinstance(objects[1], Trait)
     assert isinstance(objects[2], TraitSet)
@@ -94,11 +100,23 @@ def test_read_original_clinvar_variation_634266():
     assert isinstance(objects[6], TraitSet)
     assert isinstance(objects[7], Trait)
     assert isinstance(objects[8], TraitSet)
-    assert isinstance(objects[9], ClinicalAssertion)
-    assert isinstance(objects[10], ClinicalAssertion)
+
+    assert isinstance(objects[9], Submitter)
+    assert isinstance(objects[10], Submission)
     assert isinstance(objects[11], ClinicalAssertion)
-    assert isinstance(objects[12], ClinicalAssertion)
-    assert isinstance(objects[13], VariationArchive)
+
+    assert isinstance(objects[12], Submitter)
+    assert isinstance(objects[13], Submission)
+    assert isinstance(objects[14], ClinicalAssertion)
+
+    assert isinstance(objects[15], Submitter)
+    assert isinstance(objects[16], Submission)
+    assert isinstance(objects[17], ClinicalAssertion)
+
+    assert isinstance(objects[18], Submitter)
+    assert isinstance(objects[19], Submission)
+    assert isinstance(objects[20], ClinicalAssertion)
+    assert isinstance(objects[21], VariationArchive)
 
     # Verify variation
     variation = objects[0]
@@ -118,7 +136,7 @@ def test_read_original_clinvar_variation_634266():
     ]
 
     # Verify variation archive
-    variation_archive = objects[13]
+    variation_archive = objects[21]
     assert variation_archive.id == "VCV000634266"
     assert variation_archive.name == "CYP2C19*12/*34"
     assert variation_archive.date_created == "2019-06-17"
@@ -141,47 +159,51 @@ def test_read_original_clinvar_variation_634266():
     assert "GeneList" in variation.content
 
     # SCVs - TODO build out further
-    scv = objects[9]
-    assert scv.assertion_id == "1801318"
-    submitter = scv.submitter
-    assert submitter.id == "505961"
-    assert (
-        submitter.current_name == "Clinical Pharmacogenetics Implementation Consortium"
-    )
-    submission = scv.submission
-    assert submission.id == "505961"
-    assert submission.submission_date == "2018-03-01"
-
-    scv = objects[10]
-    assert scv.assertion_id == "1801467"
-    submitter = scv.submitter
-    assert submitter.id == "505961"
-    assert (
-        submitter.current_name == "Clinical Pharmacogenetics Implementation Consortium"
-    )
-    submission = scv.submission
-    assert submission.id == "505961"
-    assert submission.submission_date == "2018-03-01"
-
+    # SCV 1
     scv = objects[11]
-    assert scv.assertion_id == "1802126"
-    submitter = scv.submitter
+    assert scv.assertion_id == "1801318"
+    submitter = objects[9]
     assert submitter.id == "505961"
     assert (
         submitter.current_name == "Clinical Pharmacogenetics Implementation Consortium"
     )
-    submission = scv.submission
+    submission = objects[10]
     assert submission.id == "505961"
     assert submission.submission_date == "2018-03-01"
 
-    scv = objects[12]
-    assert scv.assertion_id == "1802127"
-    submitter = scv.submitter
+    # SCV 2
+    scv = objects[14]
+    assert scv.assertion_id == "1801467"
+    submitter = objects[12]
     assert submitter.id == "505961"
     assert (
         submitter.current_name == "Clinical Pharmacogenetics Implementation Consortium"
     )
-    submission = scv.submission
+    submission = objects[13]
+    assert submission.id == "505961"
+    assert submission.submission_date == "2018-03-01"
+
+    # SCV 3
+    scv = objects[17]
+    assert scv.assertion_id == "1802126"
+    submitter = objects[15]
+    assert submitter.id == "505961"
+    assert (
+        submitter.current_name == "Clinical Pharmacogenetics Implementation Consortium"
+    )
+    submission = objects[16]
+    assert submission.id == "505961"
+    assert submission.submission_date == "2018-03-01"
+
+    # SCV 4
+    scv = objects[20]
+    assert scv.assertion_id == "1802127"
+    submitter = objects[18]
+    assert submitter.id == "505961"
+    assert (
+        submitter.current_name == "Clinical Pharmacogenetics Implementation Consortium"
+    )
+    submission = objects[19]
     assert submission.id == "505961"
     assert submission.submission_date == "2018-03-01"
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,4 +1,4 @@
-from clinvar_ingest.utils import extract, extract_in, extract_oneof
+from clinvar_ingest.utils import extract, extract_oneof
 
 
 def test_extract():
@@ -20,20 +20,20 @@ def test_extract_in():
     I added 'def test_extract_in():', and the rest was added by copilot. Only one assert was wrong.
     """
     d = {"A": {"B": {"C": "C-1"}}}
-    assert extract_in(d, "A", "B", "C") == "C-1"
+    assert extract(d, "A", "B", "C") == "C-1"
     assert "C" not in d["A"]["B"]
-    assert extract_in(d, "A", "B", "C") is None
-    assert extract_in(d, "A", "B", "D") is None
-    assert extract_in(d, "A", "B") == {}
+    assert extract(d, "A", "B", "C") is None
+    assert extract(d, "A", "B", "D") is None
+    assert extract(d, "A", "B") == {}
     assert "B" not in d["A"]
-    assert extract_in(d, "A", "B") is None
+    assert extract(d, "A", "B") is None
     # This was added by copilot but is wrong, B was already removed in extract_in(d, "A", "B").
     # assert extract_in(d, "A") == {"B": {}}
     # The following was added a correction to the above case.
     # It was also added by copilot, which somehow figured out the correct
     # expected result after I added the above comments.
-    assert extract_in(d, "A") == {}
-    assert extract_in(d, "A") is None
-    assert extract_in(d, "B") is None
-    assert extract_in(d, "A", "B", "C", "D") is None
-    assert extract_in(d, "A", "B", "C", "D", "E") is None
+    assert extract(d, "A") == {}
+    assert extract(d, "A") is None
+    assert extract(d, "B") is None
+    assert extract(d, "A", "B", "C", "D") is None
+    assert extract(d, "A", "B", "C", "D", "E") is None

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -7,7 +7,6 @@ main:
                 - output_to_input_key_names:
                     copy: {"gcs_path": "input_path"}
                     parse: {"parsed_files": "source_table_paths"}
-                    create_external_tables: {"root": "root"}
                 - base_url: '${sys.get_env("CLOUD_RUN_SERVICE_URL") + "/"}'
         - create_workflow_execution:
             call: http.post
@@ -20,6 +19,7 @@ main:
         - init_workflow_execution_id:
             assign:
                 - workflow_execution_id: ${workflow_execution_step_result.body.workflow_execution_id}
+                - args["destination_dataset"]: ${workflow_execution_id}
         - for_in_steps:
             for:
                 value: step
@@ -67,18 +67,21 @@ main:
                         raise: '${"Step " + step + " failed for " + args.Name + " " + status_check_result.body.message}'
                     - step_succeeded:
                         steps:
-                            - update_args_with_step_results:
-                                for:
-                                    value: output_key
-                                    in: ${keys(output_to_input_key_names[step])}
-                                    steps:
-                                        - log_json:
-                                            call: sys.log
-                                            args:
-                                                data: '${json.decode(status_check_result.body.message)}'
-                                        - assign_vars:
-                                            assign:
-                                                - json_message: ${json.decode(status_check_result.body.message)}
-                                                - input_key: ${output_to_input_key_names[step][output_key]}
-                                                - args[input_key]: ${json_message[output_key]}
-
+                            - conditional_update_args_for_next_step:
+                                  switch:
+                                      - condition: ${step in output_to_input_key_names}
+                                        steps:
+                                            - update_args_with_step_results:
+                                                for:
+                                                    value: output_key
+                                                    in: ${keys(output_to_input_key_names[step])}
+                                                    steps:
+                                                        - log_json:
+                                                            call: sys.log
+                                                            args:
+                                                                data: '${json.decode(status_check_result.body.message)}'
+                                                        - assign_vars:
+                                                            assign:
+                                                                - json_message: ${json.decode(status_check_result.body.message)}
+                                                                - input_key: ${output_to_input_key_names[step][output_key]}
+                                                                - args[input_key]: ${json_message[output_key]}

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -4,18 +4,31 @@ main:
         - init:
             assign:
                 - ingest_steps:
-                    - copy: ["ftp_path", "gcs_path"]
-                    - parse: ["parsed_files"]
-                    - create_external_tables: ["root"]
+                    copy: ["ftp_path", "gcs_path"]
+                    parse: ["parsed_files"]
+                    create_external_tables: ["root"]
                 - base_url: '${sys.get_env("CLOUD_RUN_SERVICE_URL") + "/"}'
                 - initialize_step_url: '${base_url + "initialize_step"}'
                 - step_status_url: '${base_url + "step_status"}'
+                - workflow_execution_step_url: '${base_url + "create_workflow_execution_id/"}'
                 - clinvar_file: '${args.Name}'
+        - create_workflow_execution:
+            call: http.post
+            args:
+                url: '${workflow_execution_step_url + clinvar_file}'
+                body:
+                auth:
+                    type: OIDC
+            result: workflow_execution_step_result
         - for_in_steps:
             for:
                 value: step
-                in: ${ingest_steps}
+                in: ${keys(ingest_steps)}
                 steps:
+                    - log_step_key:
+                        call: sys.log
+                        args:
+                            data: '${"Step is: " + step}'
                     - init_variables:
                         assign:
                             - step_name: '${text.to_upper(step)}'

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -4,10 +4,9 @@ main:
         - init:
             assign:
                 - ingest_steps:
-                    - copy
-                    - parse
-                    - create_external_tables
-                    - create_internal_tables
+                    - copy: ["ftp_path", "gcs_path"]
+                    - parse: ["parsed_files"]
+                    - create_external_tables: ["root"]
                 - base_url: '${sys.get_env("CLOUD_RUN_SERVICE_URL") + "/"}'
                 - initialize_step_url: '${base_url + "initialize_step"}'
                 - step_status_url: '${base_url + "step_status"}'
@@ -17,9 +16,10 @@ main:
                 value: step
                 in: ${ingest_steps}
                 steps:
-                    - init_vars:
+                    - init_variables:
                         assign:
                             - step_name: '${text.to_upper(step)}'
+                            - result_copy_vars: ingest_steps[step]
                     - log_execute_args:
                         call: sys.log
                         args:
@@ -56,7 +56,7 @@ main:
                             url: '${step_status_url}'
                             body:
                                 step_name: '${step_name}'
-                                file: '${clinvar_file}'
+                                workflow_execution_id: '${clinvar_file}'
                             auth:
                                 type: OIDC
                         result: status_check_result
@@ -66,16 +66,26 @@ main:
                             data: '${status_check_result}'
                     - check_if_complete:
                         switch:
-                            - condition: ${"FAILED"== status_check_result}
+                            - condition: ${"FAILED" == status_check_result}
                               next: step_failed
                             - condition: ${"SUCCEEDED" == status_check_result}
                               next: step_succeeded
                     - wait_for_result:
                         call: sys.sleep
                         args:
-                            seconds: 300
+                            seconds: 120
                         next: status_check
                     - step_succeeded:
-                        return: '${"Step " + step_name + " succeeded for " + clinvar_file + " " + status_check_result.complete}'
+                        steps:
+                            - update_args_with_step_results:
+                                for:
+                                    value: var
+                                    in: ${result_copy_vars}
+                                    steps:
+                                        - assign_vars:
+                                            assign:
+                                                - args[var]: ${status_check_result[var]}
+                            - return_args:
+                                return: args
                     - step_failed:
                         raise: '${"Step " + step_name + " failed for " + clinvar_file + " " + status_check_result.failure}'

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -3,58 +3,36 @@ main:
     steps:
         - init:
             assign:
-                - ingest_steps:
-                    copy: ["ftp_path", "gcs_path"]
-                    parse: ["parsed_files"]
-                    create_external_tables: ["root"]
+                - ordered_steps: ["copy", "parse", "create_external_tables"]
+                - output_to_input_key_names:
+                    copy: {"gcs_path": "input_path"}
+                    parse: {"parsed_files": "source_table_paths"}
+                    create_external_tables: {"root": "root"}
                 - base_url: '${sys.get_env("CLOUD_RUN_SERVICE_URL") + "/"}'
-                - initialize_step_url: '${base_url + "initialize_step"}'
-                - step_status_url: '${base_url + "step_status"}'
-                - workflow_execution_step_url: '${base_url + "create_workflow_execution_id/"}'
-                - clinvar_file: '${args.Name}'
         - create_workflow_execution:
             call: http.post
             args:
-                url: '${workflow_execution_step_url + clinvar_file}'
+                url: '${base_url + "create_workflow_execution_id/" + args["Release Date"]}'
                 body:
                 auth:
                     type: OIDC
             result: workflow_execution_step_result
+        - init_workflow_execution_id:
+            assign:
+                - workflow_execution_id: ${workflow_execution_step_result.body.workflow_execution_id}
         - for_in_steps:
             for:
                 value: step
-                in: ${keys(ingest_steps)}
+                in: ${ordered_steps}
                 steps:
                     - log_step_key:
                         call: sys.log
                         args:
-                            data: '${"Step is: " + step}'
-                    - init_variables:
-                        assign:
-                            - step_name: '${text.to_upper(step)}'
-                            - result_copy_vars: ingest_steps[step]
-                    - log_execute_args:
-                        call: sys.log
-                        args:
-                            data: '${"executing: " + step_name + " " + base_url + step + " " + clinvar_file}'
-                    - initialize_step:
-                        call: http.post
-                        args:
-                            url: '${initialize_step_url}'
-                            body:
-                                step_name: '${step_name}'
-                                workflow_execution_id: '${clinvar_file}'
-                            auth:
-                                type: OIDC
-                        result: initialize_step_result
-                    - log_initialize_step_result:
-                        call: sys.log
-                        args:
-                            data: '${initialize_step_result}'
+                            data: '${"Step is: " + step + " workflow_execution_id is: " + workflow_execution_id}'
                     - call_step:
                         call: http.post
                         args:
-                            url: '${base_url + step}'
+                            url: '${base_url + step + "/" + workflow_execution_id}'
                             body: '${args}'
                             auth:
                                 type: OIDC
@@ -64,12 +42,9 @@ main:
                         args:
                             data: '${call_step_result}'
                     - status_check:
-                        call: http.post
+                        call: http.get
                         args:
-                            url: '${step_status_url}'
-                            body:
-                                step_name: '${step_name}'
-                                workflow_execution_id: '${clinvar_file}'
+                            url: '${base_url + "step_status/" + workflow_execution_id + "/" + step}'
                             auth:
                                 type: OIDC
                         result: status_check_result
@@ -79,26 +54,31 @@ main:
                             data: '${status_check_result}'
                     - check_if_complete:
                         switch:
-                            - condition: ${"FAILED" == status_check_result}
+                            - condition: ${"FAILED" == status_check_result.body.step_status}
                               next: step_failed
-                            - condition: ${"SUCCEEDED" == status_check_result}
+                            - condition: ${"SUCCEEDED" == status_check_result.body.step_status}
                               next: step_succeeded
                     - wait_for_result:
                         call: sys.sleep
                         args:
-                            seconds: 120
+                            seconds: 60
                         next: status_check
+                    - step_failed:
+                        raise: '${"Step " + step + " failed for " + args.Name + " " + status_check_result.body.message}'
                     - step_succeeded:
                         steps:
                             - update_args_with_step_results:
                                 for:
-                                    value: var
-                                    in: ${result_copy_vars}
+                                    value: output_key
+                                    in: ${keys(output_to_input_key_names[step])}
                                     steps:
+                                        - log_json:
+                                            call: sys.log
+                                            args:
+                                                data: '${json.decode(status_check_result.body.message)}'
                                         - assign_vars:
                                             assign:
-                                                - args[var]: ${status_check_result[var]}
-                            - return_args:
-                                return: args
-                    - step_failed:
-                        raise: '${"Step " + step_name + " failed for " + clinvar_file + " " + status_check_result.failure}'
+                                                - json_message: ${json.decode(status_check_result.body.message)}
+                                                - input_key: ${output_to_input_key_names[step][output_key]}
+                                                - args[input_key]: ${json_message[output_key]}
+

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -1,56 +1,81 @@
 main:
     params: [args]
     steps:
-        - log_args:
-            call: sys.log
-            args:
-                data: ${args}
-        - copy:
-            call: http.post
-            args:
-                url: https://clinvar-ingest-kyle-dev-qmojsrhb3q-uc.a.run.app/copy
-                #url: '${sys.get_env("CLOUD_RUN_SERVICE")}/copy'
-                body: '${args}'
-                auth:
-                    type: OIDC
-            result: copy_result
-        - log_copy_result:
-            call: sys.log
-            args:
-                data: ${copy_result}
-        - parse:
-            try:
-                call: http.post
-                args:
-                    url: https://clinvar-ingest-kyle-dev-qmojsrhb3q-uc.a.run.app/parse
-                    #url: '${sys.get_env("CLOUD_RUN_SERVICE")}/parse'
-                    # body: '${copy_result.body}'
-                    body:
-                        input_path: '${copy_result.body.gcs_path}'
-                        output_path: 'gs://clinvar-ingest/wf-outputs'
-                    auth:
-                        type: OIDC
-                result: parse_result
-            except:
-                as: e
+        - init:
+            assign:
+                - ingest_steps:
+                    - copy
+                    - parse
+                    - create_external_tables
+                    - create_internal_tables
+                - base_url: '${sys.get_env("CLOUD_RUN_SERVICE_URL") + "/"}'
+                - initialize_step_url: '${base_url + "initialize_step"}'
+                - step_status_url: '${base_url + "step_status"}'
+                - clinvar_file: '${args.Name}'
+        - for_in_steps:
+            for:
+                value: step
+                in: ${ingest_steps}
                 steps:
-                    - unhandled_exception:
-                        raise: ${e}
-        - log_parse_result:
-            call: sys.log
-            args:
-                data: ${parse_result}
-        - create_external_tables:
-            call: http.post
-            args:
-                url: https://clinvar-ingest-kyle-dev-qmojsrhb3q-uc.a.run.app/create_external_tables
-                #url: '${sys.get_env("CLOUD_RUN_SERVICE")}/create_external_tables'
-                body:
-                    destination_project: clingen-dev
-                    destination_dataset: clinvar_ingest_new_wf_kyle_dev
-                    source_table_paths: '${parse_result.body.parsed_files}'
-                auth:
-                    type: OIDC
-            result: create_external_tables_result
-        - result:
-            return: ${create_external_tables_result}
+                    - init_vars:
+                        assign:
+                            - step_name: '${text.to_upper(step)}'
+                    - log_execute_args:
+                        call: sys.log
+                        args:
+                            data: '${"executing: " + step_name + " " + base_url + step + " " + clinvar_file}'
+                    - initialize_step:
+                        call: http.post
+                        args:
+                            url: '${initialize_step_url}'
+                            body:
+                                step_name: '${step_name}'
+                                workflow_execution_id: '${clinvar_file}'
+                            auth:
+                                type: OIDC
+                        result: initialize_step_result
+                    - log_initialize_step_result:
+                        call: sys.log
+                        args:
+                            data: '${initialize_step_result}'
+                    - call_step:
+                        call: http.post
+                        args:
+                            url: '${base_url + step}'
+                            body: '${args}'
+                            auth:
+                                type: OIDC
+                        result: call_step_result
+                    - log_call_step_result:
+                        call: sys.log
+                        args:
+                            data: '${call_step_result}'
+                    - status_check:
+                        call: http.post
+                        args:
+                            url: '${step_status_url}'
+                            body:
+                                step_name: '${step_name}'
+                                file: '${clinvar_file}'
+                            auth:
+                                type: OIDC
+                        result: status_check_result
+                    - log_status_check_result:
+                        call: sys.log
+                        args:
+                            data: '${status_check_result}'
+                    - check_if_complete:
+                        switch:
+                            - condition: ${"FAILED"== status_check_result}
+                              next: step_failed
+                            - condition: ${"SUCCEEDED" == status_check_result}
+                              next: step_succeeded
+                    - wait_for_result:
+                        call: sys.sleep
+                        args:
+                            seconds: 300
+                        next: status_check
+                    - step_succeeded:
+                        return: '${"Step " + step_name + " succeeded for " + clinvar_file + " " + status_check_result.complete}'
+                    - step_failed:
+                        raise: '${"Step " + step_name + " failed for " + clinvar_file + " " + status_check_result.failure}'

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -8,10 +8,11 @@ main:
                     copy: {"gcs_path": "input_path"}
                     parse: {"parsed_files": "source_table_paths"}
                 - base_url: '${sys.get_env("CLOUD_RUN_SERVICE_URL") + "/"}'
+                - clinvar_release_date: ${text.replace_all(args["Release Date"], "-", "_")}
         - create_workflow_execution:
             call: http.post
             args:
-                url: '${base_url + "create_workflow_execution_id/" + args["Release Date"]}'
+                url: '${base_url + "create_workflow_execution_id/" + clinvar_release_date}'
                 body:
                 auth:
                     type: OIDC


### PR DESCRIPTION
Mega PR to:
- Refactor FastAPI to use asynchronous execution of main application tasks and writing status files instead of blocking the http response.
- Add a new `workflow.py`, `Dockerfile-workflow-py`, and `workflow-py.docker.cloudbuild.yaml` for running the workflow steps as a single python file instead of http requests. Add a `deploy-job.sh` and `execute-job.sh` to `misc/bin/` which I've been using to fully tear down and rebuild a Cloud Run Job that executes `workflow.py`
- Related to the above, fix the issue with the `/copy` endpoint silently failing to actually finish copying large files.
  - Switch to using `requests.get` (and added an option for `curl`) to download instead of `urllib.requests.urlopen`.
  - Do the download and upload of the file as two discrete steps to/from the local filesystem instead of streaming in-memory.
- Turn off all info logging from `model.py`
- Add helper function for logging the progress of some integer value on a time period. (e.g. `<N>` VCVs processed in `<T>` seconds). Switched logging in file download functions to use this. Added this to the main `parse.parse_and_write_files` function, logging the processed byte count and VCV count every 10 seconds.
- Add reader wrapper `CountReader` to add a `.tell` method to readable things like `google.cloud.storage.fileio.BlobReader` that do not report where they are in the file.
- Add `partition_testing.py` which is just a script that splits one ClinVar XML file into `N` of equal size.
  - Quick run on an GCP VM ran through in ~15m