### PR TITLE
Refactor jsonification of fields to the output file writing

### DIFF
--- a/clinvar_ingest/cli.py
+++ b/clinvar_ingest/cli.py
@@ -20,8 +20,8 @@ def parse_args(argv):
     )
     parse_sp.add_argument(
         "--jsonify-content",
-        type=bool,
-        default=True,
+        choices=["true", "false"],
+        default="true",
         help="JSON encode content fields (default: true)",
     )
 

--- a/clinvar_ingest/main.py
+++ b/clinvar_ingest/main.py
@@ -21,7 +21,7 @@ def run_parse(args):
         args.input_filename,
         args.output_directory,
         disassemble=args.disassemble,
-        jsonify_content=args.jsonify_content,
+        jsonify_content=args.jsonify_content == "true",
     )
     print(output_files)
 

--- a/clinvar_ingest/model/common.py
+++ b/clinvar_ingest/model/common.py
@@ -2,13 +2,14 @@ import dataclasses
 import logging
 import re
 from abc import ABCMeta, abstractmethod
-from typing import Union
+from typing import Any
 
 _logger = logging.getLogger("clinvar_ingest")
 
 
 class Model(object, metaclass=ABCMeta):
     @staticmethod
+    @abstractmethod
     def from_xml(inp: dict):
         """
         Constructs an instance of this class using the XML structure parsed into a dict.
@@ -26,6 +27,11 @@ class Model(object, metaclass=ABCMeta):
         Decomposes this instance into instances of contained Model classes, and itself.
         An object referred to by another will be returned before the other.
         """
+        raise NotImplementedError()
+
+    @staticmethod
+    @abstractmethod
+    def jsonifiable_fields() -> list[str]:
         raise NotImplementedError()
 
     def __repr__(self) -> str:
@@ -65,7 +71,7 @@ def model_copy(obj):
     return cls(**kwargs)
 
 
-def int_or_none(s: Union[str, None]) -> Union[int, None]:
+def int_or_none(s: str | None) -> int | None:
     if s is None:
         return None
     return int(s)
@@ -96,7 +102,9 @@ def sanitize_date(s: str) -> str:
         raise ValueError(f"Invalid date: {s}, must match {pattern_str}")
 
 
-def dictify(obj):
+def dictify(
+    obj,
+) -> dict | list[dict | Any]:  # recursive type truncated at 2nd level
     """
     Recursively dictify Python objects into dicts. Objects may be Model instances.
     """

--- a/clinvar_ingest/model/common.py
+++ b/clinvar_ingest/model/common.py
@@ -32,6 +32,32 @@ class Model(object, metaclass=ABCMeta):
     @staticmethod
     @abstractmethod
     def jsonifiable_fields() -> list[str]:
+        """
+        List of field names which can be serialized to JSON upon the object's serialization
+        for output. Field names which map to lists of objects will have each item in the
+        list serialized to JSON individually, and the list will remain a list.
+
+        Example:
+            >>> class Foo(Model):
+            ...     def __init__(self, a, b, c):
+            ...         self.a = a
+            ...         self.b = b
+            ...         self.c = c
+            ...     @staticmethod
+            ...     def jsonifiable_fields():
+            ...         return ["a", "c"]
+            >>> foo = Foo(1, 2, 3)
+            >>> foo.a = {"x": 1}
+            >>> foo.b = {"y": 2}
+            >>> foo.c = [{"z1": 3}, {"z2": 4}]
+            >>> foo_dict = dictify(foo)
+            >>> foo_dict["a"]
+            '{"x": 1}'
+            >>> foo_dict["b"]
+            {'y': 2}
+            >>> foo_dict["c"]
+            ['{"z1": 3}', '{"z2": 4}']
+        """
         raise NotImplementedError()
 
     def __repr__(self) -> str:

--- a/clinvar_ingest/model/common.py
+++ b/clinvar_ingest/model/common.py
@@ -9,7 +9,7 @@ _logger = logging.getLogger("clinvar_ingest")
 
 class Model(object, metaclass=ABCMeta):
     @staticmethod
-    def from_xml(inp: dict, jsonify_content=True):
+    def from_xml(inp: dict):
         """
         Constructs an instance of this class using the XML structure parsed into a dict.
 

--- a/clinvar_ingest/model/trait.py
+++ b/clinvar_ingest/model/trait.py
@@ -428,8 +428,7 @@ class ClinicalAssertionTrait(Model):
 
     @staticmethod
     def jsonifiable_fields() -> List[str]:
-        # TODO xrefs?
-        return ["content"]
+        return ["content", "xrefs"]
 
     def __post_init__(self):
         self.entity_type = "clinical_assertion_trait"

--- a/clinvar_ingest/model/trait.py
+++ b/clinvar_ingest/model/trait.py
@@ -121,24 +121,24 @@ class TraitMetadata(Model):
 @dataclasses.dataclass
 class Trait(Model):
     id: str
-    disease_mechanism_id: int
+    disease_mechanism_id: int | None
     name: str
     attribute_content: List[str]
-    mode_of_inheritance: str
-    ghr_links: str
-    keywords: List[str]
-    gard_id: int
+    mode_of_inheritance: str | None
+    ghr_links: str | None
+    keywords: List[str] | None
+    gard_id: int | None
     medgen_id: str
-    public_definition: str
+    public_definition: str | None
     type: str
-    symbol: str
-    disease_mechanism: str
+    symbol: str | None
+    disease_mechanism: str | None
     alternate_symbols: List[str]
-    gene_reviews_short: str
+    gene_reviews_short: str | None
     alternate_names: List[str]
     xrefs: List[str]
 
-    content: str
+    content: dict
 
     @staticmethod
     def jsonifiable_fields() -> List[str]:

--- a/clinvar_ingest/model/trait.py
+++ b/clinvar_ingest/model/trait.py
@@ -48,6 +48,10 @@ class TraitMetadata(Model):
     xrefs: List[Trait.XRef]
 
     @staticmethod
+    def jsonifiable_fields() -> List[str]:
+        return ["xrefs"]
+
+    @staticmethod
     def from_xml(inp: dict):
         # _logger.info(f"TraitMetadata.from_xml(inp={json.dumps(inp)})")
 
@@ -622,6 +626,10 @@ class TraitMapping(Model):
     mapping_ref: str
     medgen_name: str
     medgen_id: str
+
+    @staticmethod
+    def jsonifiable_fields() -> List[str]:
+        return []
 
     def __post_init__(self):
         self.entity_type = "trait_mapping"

--- a/clinvar_ingest/model/trait.py
+++ b/clinvar_ingest/model/trait.py
@@ -47,10 +47,8 @@ class TraitMetadata(Model):
     alternate_names: List[str]
     xrefs: List[Trait.XRef]
 
-    # content: dict
-
     @staticmethod
-    def from_xml(inp: dict, jsonify_content=True):
+    def from_xml(inp: dict):
         # _logger.info(f"TraitMetadata.from_xml(inp={json.dumps(inp)})")
 
         id = extract(inp, "@ID")
@@ -138,6 +136,10 @@ class Trait(Model):
 
     content: str
 
+    @staticmethod
+    def jsonifiable_fields() -> List[str]:
+        return ["content", "attribute_content", "xrefs"]
+
     class XRef:
         def __init__(
             self,
@@ -166,10 +168,10 @@ class Trait(Model):
         self.entity_type = "trait"
 
     @staticmethod
-    def from_xml(inp: dict, jsonify_content=True) -> Trait:
+    def from_xml(inp: dict) -> Trait:
         _logger.debug(f"Trait.from_xml(inp={json.dumps(inp)})")
 
-        trait_metadata = TraitMetadata.from_xml(inp, jsonify_content=jsonify_content)
+        trait_metadata = TraitMetadata.from_xml(inp)
 
         # TODO the logic here is the same as Preferred and Alternate Name
         # Preferred Symbol (Symbol type=Preferred)
@@ -366,10 +368,6 @@ class Trait(Model):
             attribute_content=attribute_set,
             content=inp,
         )
-        if jsonify_content:
-            obj.content = json.dumps(inp)
-            obj.attribute_content = [json.dumps(a) for a in attribute_set]
-            obj.xrefs = [json.dumps(dictify(x)) for x in all_xrefs]
         return obj
 
     def disassemble(self):
@@ -382,28 +380,26 @@ class TraitSet(Model):
     type: str
     traits: List[Trait]
 
-    content: str
+    content: dict
+
+    @staticmethod
+    def jsonifiable_fields() -> List[str]:
+        return ["content"]
 
     def __post_init__(self):
         self.trait_ids = [t.id for t in self.traits]
         self.entity_type = "trait_set"
 
     @staticmethod
-    def from_xml(inp: dict, jsonify_content=True):
+    def from_xml(inp: dict):
         _logger.debug(f"TraitSet.from_xml(inp={json.dumps(dictify(inp))})")
         obj = TraitSet(
             id=extract(inp, "@ID"),
             type=extract(inp, "@Type"),
-            traits=[
-                Trait.from_xml(t, jsonify_content=jsonify_content)
-                for t in ensure_list(extract(inp, "Trait"))
-            ],
+            traits=[Trait.from_xml(t) for t in ensure_list(extract(inp, "Trait"))],
             content=inp,
         )
-        if jsonify_content:
-            obj.content = json.dumps(inp)
-            for t in obj.traits:
-                t.content = json.dumps(t.content)
+
         return obj
 
     def disassemble(self):
@@ -425,6 +421,11 @@ class ClinicalAssertionTrait(Model):
     xrefs: List[Trait.XRef]
 
     content: dict
+
+    @staticmethod
+    def jsonifiable_fields() -> List[str]:
+        # TODO xrefs?
+        return ["content"]
 
     def __post_init__(self):
         self.entity_type = "clinical_assertion_trait"
@@ -521,7 +522,6 @@ class ClinicalAssertionTrait(Model):
     @staticmethod
     def from_xml(
         inp: dict,
-        jsonify_content=True,
         normalized_traits: List[Trait] = [],
         trait_mappings: List[TraitMapping] = [],
     ):
@@ -529,7 +529,7 @@ class ClinicalAssertionTrait(Model):
             f"ClinicalAssertionTrait.from_xml(inp={json.dumps(dictify(inp))})"
         )
 
-        trait_metadata = TraitMetadata.from_xml(inp, jsonify_content=jsonify_content)
+        trait_metadata = TraitMetadata.from_xml(inp)
 
         # Map submitted trait to normalized trait
         matching_trait = ClinicalAssertionTrait.find_matching_trait(
@@ -551,9 +551,6 @@ class ClinicalAssertionTrait(Model):
             xrefs=trait_metadata.xrefs,
             content=inp,
         )
-        if jsonify_content:
-            obj.content = json.dumps(obj.content)
-            obj.xrefs = [json.dumps(dictify(x)) for x in obj.xrefs]
         return obj
 
     def disassemble(self):
@@ -574,13 +571,16 @@ class ClinicalAssertionTraitSet(Model):
     traits: List[ClinicalAssertionTrait]
     content: dict
 
+    @staticmethod
+    def jsonifiable_fields() -> List[str]:
+        return ["content"]
+
     def __post_init__(self):
         self.entity_type = "clinical_assertion_trait_set"
 
     @staticmethod
     def from_xml(
         inp: dict,
-        jsonify_content=True,
         normalized_traits: List[Trait] = [],
         trait_mappings: List[TraitMapping] = [],
     ):
@@ -593,7 +593,6 @@ class ClinicalAssertionTraitSet(Model):
             traits=[
                 ClinicalAssertionTrait.from_xml(
                     t,
-                    jsonify_content=jsonify_content,
                     normalized_traits=normalized_traits,
                     trait_mappings=trait_mappings,
                 )
@@ -601,8 +600,6 @@ class ClinicalAssertionTraitSet(Model):
             ],
             content=inp,
         )
-        if jsonify_content:
-            obj.content = json.dumps(obj.content)
         return obj
 
     def disassemble(self):
@@ -630,7 +627,7 @@ class TraitMapping(Model):
         self.entity_type = "trait_mapping"
 
     @staticmethod
-    def from_xml(inp: dict, jsonify_content=True):
+    def from_xml(inp: dict):
         return TraitMapping(
             clinical_assertion_id=extract(inp, "@ClinicalAssertionID"),
             trait_type=extract(inp, "@TraitType"),

--- a/clinvar_ingest/model/variation_archive.py
+++ b/clinvar_ingest/model/variation_archive.py
@@ -138,7 +138,7 @@ class ClinicalAssertionObservation(Model):
                 yield subobj
         else:
             setattr(self_copy, "clinical_assertion_trait_set_id", None)
-        yield self
+        yield self_copy
 
 
 @dataclasses.dataclass
@@ -306,6 +306,10 @@ class Gene(Model):
     id: str
     symbol: str
     full_name: str
+
+    @staticmethod
+    def jsonifiable_fields() -> List[str]:
+        return []
 
     def __post_init__(self):
         self.entity_type = "gene"

--- a/clinvar_ingest/model/variation_archive.py
+++ b/clinvar_ingest/model/variation_archive.py
@@ -41,12 +41,16 @@ class Submitter(Model):
     org_category: str
     content: dict
 
+    @staticmethod
+    def jsonifiable_fields() -> List[str]:
+        return ["content"]
+
     def __post_init__(self):
         self.entity_type = "submitter"
 
     @staticmethod
-    def from_xml(inp: dict, jsonify_content=True):
-        _logger.debug(f"Submitter.from_xml(inp={json.dumps(inp)}, {jsonify_content=})")
+    def from_xml(inp: dict):
+        _logger.debug(f"Submitter.from_xml(inp={json.dumps(inp)})")
         current_name = extract(inp, "@SubmitterName")
         current_abbrev = extract(inp, "@OrgAbbreviation")
         obj = Submitter(
@@ -58,8 +62,6 @@ class Submitter(Model):
             all_abbrevs=[] if not current_abbrev else [current_abbrev],
             content=inp,
         )
-        if jsonify_content:
-            obj.content = json.dumps(inp)
         return obj
 
     def disassemble(self):
@@ -74,18 +76,21 @@ class Submission(Model):
     submission_date: str
     content: dict
 
+    @staticmethod
+    def jsonifiable_fields() -> List[str]:
+        return ["content"]
+
     def __post_init__(self):
         self.entity_type = "submission"
 
     @staticmethod
     def from_xml(
         inp: dict,
-        jsonify_content=True,
         submitter: Submitter = {},
         additional_submitters: list = [Submitter],
     ):
         _logger.debug(
-            f"Submission.from_xml(inp={json.dumps(inp)}, {jsonify_content=}, {submitter=}, "
+            f"Submission.from_xml(inp={json.dumps(inp)}, {submitter=}, "
             f"{additional_submitters=})"
         )
         obj = Submission(
@@ -95,8 +100,6 @@ class Submission(Model):
             submission_date=sanitize_date(extract(inp, "@SubmissionDate")),
             content=inp,
         )
-        if jsonify_content:
-            obj.content = json.dumps(inp)
         return obj
 
     def disassemble(self):
@@ -111,14 +114,18 @@ class ClinicalAssertionObservation(Model):
     # This is redudant information, so don't inclue the whole TraitSet here, just the id
     # TODO this is actually referring to a TraitSet which can be nested under the ObservedIn element
     # That TraitSet should come out as a ClinicalAssertionTraitSet, and the id should go here
-    clinical_assertion_trait_set: ClinicalAssertionTraitSet
+    clinical_assertion_trait_set: ClinicalAssertionTraitSet | None
     content: dict
+
+    @staticmethod
+    def jsonifiable_fields() -> List[str]:
+        return ["content"]
 
     def __post_init__(self):
         self.entity_type = "clinical_assertion_observation"
 
     @staticmethod
-    def from_xml(inp: dict, jsonify_content=True):
+    def from_xml(inp: dict):
         raise NotImplementedError()
 
     def disassemble(self):
@@ -154,7 +161,11 @@ class ClinicalAssertion(Model):
     content: dict
 
     clinical_assertion_observations: List[ClinicalAssertionObservation]
-    clinical_assertion_trait_set: ClinicalAssertionTraitSet
+    clinical_assertion_trait_set: ClinicalAssertionTraitSet | None
+
+    @staticmethod
+    def jsonifiable_fields() -> List[str]:
+        return ["content"]
 
     def __post_init__(self):
         self.entity_type = "clinical_assertion"
@@ -162,13 +173,10 @@ class ClinicalAssertion(Model):
     @staticmethod
     def from_xml(
         inp: dict,
-        jsonify_content=True,
         normalized_traits: List[Trait] = [],
         trait_mappings: List[TraitMapping] = [],
     ):
-        _logger.debug(
-            f"ClinicalAssertion.from_xml(inp={json.dumps(inp)}, {jsonify_content=})"
-        )
+        _logger.debug(f"ClinicalAssertion.from_xml(inp={json.dumps(inp)})")
         obj_id = extract(inp, "@ID")
         raw_accession = extract(inp, "ClinVarAccession")
         scv_accession = extract(raw_accession, "@Accession")
@@ -186,16 +194,13 @@ class ClinicalAssertion(Model):
             )
         )
         submitter = Submitter.from_xml(raw_accession)
-        submission = Submission.from_xml(
-            inp, jsonify_content, submitter, additional_submitters
-        )
+        submission = Submission.from_xml(inp, submitter, additional_submitters)
 
         trait_set_counter = make_counter()
         assertion_trait_set = extract(inp, "TraitSet")
         if assertion_trait_set is not None:
             assertion_trait_set = ClinicalAssertionTraitSet.from_xml(
                 assertion_trait_set,
-                jsonify_content=jsonify_content,
                 normalized_traits=normalized_traits,
                 trait_mappings=trait_mappings,
             )
@@ -212,7 +217,6 @@ class ClinicalAssertion(Model):
                 clinical_assertion_trait_set=(
                     ClinicalAssertionTraitSet.from_xml(
                         extract(o, "TraitSet"),
-                        jsonify_content=jsonify_content,
                         normalized_traits=normalized_traits,
                         trait_mappings=trait_mappings,
                     )
@@ -260,10 +264,6 @@ class ClinicalAssertion(Model):
             clinical_assertion_trait_set=assertion_trait_set,
             content=inp,
         )
-        if jsonify_content:
-            obj.content = json.dumps(inp)
-            for observation in obj.clinical_assertion_observations:
-                observation.content = json.dumps(observation.content)
         return obj
 
     def disassemble(self):
@@ -326,12 +326,16 @@ class GeneAssociation(Model):
     relationship_type: str
     content: dict
 
+    @staticmethod
+    def jsonifiable_fields() -> List[str]:
+        return ["content"]
+
     def __post_init__(self):
         self.gene_id = self.gene.id
         self.entity_type = "gene_association"
 
     @staticmethod
-    def from_xml(inp: dict, jsonify_content=True):
+    def from_xml(inp: dict):
         raise NotImplementedError()
 
     def disassemble(self):
@@ -358,12 +362,16 @@ class Variation(Model):
     child_ids: List[str]
     descendant_ids: List[str]
 
+    @staticmethod
+    def jsonifiable_fields() -> List[str]:
+        return ["content"]
+
     def __post_init__(self):
         self.entity_type = "variation"
 
     @staticmethod
-    def from_xml(inp: dict, jsonify_content=True):
-        _logger.debug(f"Variation.from_xml(inp={json.dumps(inp)}), {jsonify_content=}")
+    def from_xml(inp: dict):
+        _logger.debug(f"Variation.from_xml(inp={json.dumps(inp)})")
         descendant_tree = Variation.descendant_tree(inp)
         # _logger.info(f"descendant_tree: {descendant_tree}")
         child_ids = Variation.get_all_children(descendant_tree)
@@ -416,11 +424,6 @@ class Variation(Model):
             )
             for g in ensure_list(extract(extract(inp, "GeneList"), "Gene") or [])
         ]
-
-        if jsonify_content:
-            obj.content = json.dumps(inp)
-            for ga in obj.gene_associations:
-                ga.content = json.dumps(ga.content)
         return obj
 
     @staticmethod
@@ -488,7 +491,7 @@ class Variation(Model):
         return child_ids + grandchildren
 
     @staticmethod
-    def get_all_children(descendant_tree: tuple):
+    def get_all_children(descendant_tree: list):
         """
         Accepts a descendant_tree. Returns the first level children.
         """
@@ -525,13 +528,16 @@ class RcvAccession(Model):
 
     content: dict
 
+    @staticmethod
+    def jsonifiable_fields() -> List[str]:
+        return ["content"]
+
     def __post_init__(self):
         self.entity_type = "rcv_accession"
 
     @staticmethod
     def from_xml(
         inp: dict,
-        jsonify_content=True,
         variation_id: int = None,
         variation_archive_id=None,
     ) -> RcvAccession:
@@ -570,8 +576,6 @@ class RcvAccession(Model):
             interpretation=extract(inp, "@Interpretation"),
             content=inp,
         )
-        if jsonify_content:
-            obj.content = json.dumps(obj.content)
         return obj
 
     def disassemble(self):
@@ -604,21 +608,23 @@ class VariationArchive(Model):
 
     rcv_accessions: List[RcvAccession]
 
+    @staticmethod
+    def jsonifiable_fields() -> List[str]:
+        return ["content", "interp_content"]
+
     def __post_init__(self):
         self.variation_id = self.variation.id
         self.entity_type = "variation_archive"
 
     @staticmethod
-    def from_xml(inp: dict, jsonify_content=True):
-        _logger.debug(
-            f"VariationArchive.from_xml(inp={json.dumps(inp)}, {jsonify_content=})"
-        )
+    def from_xml(inp: dict):
+        _logger.debug(f"VariationArchive.from_xml(inp={json.dumps(inp)})")
         interp_record = inp.get("InterpretedRecord", inp.get("IncludedRecord"))
         interpretations = extract(interp_record, "Interpretations")
         interpretation = interpretations["Interpretation"]
-        variation = Variation.from_xml(interp_record, jsonify_content=jsonify_content)
+        variation = Variation.from_xml(interp_record)
         trait_mappings = [
-            TraitMapping.from_xml(tm, jsonify_content=jsonify_content)
+            TraitMapping.from_xml(tm)
             for tm in ensure_list(
                 extract(
                     extract(
@@ -631,7 +637,7 @@ class VariationArchive(Model):
             )
         ]
         trait_sets = [
-            TraitSet.from_xml(ts, jsonify_content=jsonify_content)
+            TraitSet.from_xml(ts)
             for ts in ensure_list(
                 extract(
                     interpretation,
@@ -650,7 +656,6 @@ class VariationArchive(Model):
             clinical_assertions=[
                 ClinicalAssertion.from_xml(
                     ca,
-                    jsonify_content,
                     normalized_traits=flatten1([ts.traits for ts in trait_sets]),
                     trait_mappings=trait_mappings,
                 )
@@ -683,7 +688,6 @@ class VariationArchive(Model):
             rcv_accessions=[
                 RcvAccession.from_xml(
                     r,
-                    jsonify_content=jsonify_content,
                     variation_id=variation.id,
                     variation_archive_id=_id,
                 )
@@ -694,9 +698,6 @@ class VariationArchive(Model):
             interp_content=interpretation,
             content=inp,
         )
-        if jsonify_content:
-            obj.content = json.dumps(inp)
-            obj.interp_content = json.dumps(interpretation)
         return obj
 
     def disassemble(self):

--- a/clinvar_ingest/parse.py
+++ b/clinvar_ingest/parse.py
@@ -65,7 +65,7 @@ def get_open_file_for_writing(
 
 def parse_and_write_files(
     input_filename: str, output_directory: str, disassemble=True, jsonify_content=True
-) -> list:
+) -> dict[str, str]:
     """
     Parses input file, writes outputs to output directory.
 
@@ -111,7 +111,12 @@ def parse_and_write_files(
                     if hasattr(type(obj), "jsonifiable_fields"):
                         for field in getattr(type(obj), "jsonifiable_fields")():
                             if field in obj_dict:
-                                obj_dict[field] = json.dumps(obj_dict[field])
+                                if isinstance(obj_dict[field], list):
+                                    obj_dict[field] = [
+                                        json.dumps(i) for i in obj_dict[field]
+                                    ]
+                                else:
+                                    obj_dict[field] = json.dumps(obj_dict[field])
 
                 obj_dict["release_date"] = release_date
                 f_out.write(json.dumps(obj_dict).encode("utf-8"))

--- a/clinvar_ingest/reader.py
+++ b/clinvar_ingest/reader.py
@@ -18,11 +18,11 @@ _logger = logging.getLogger("clinvar_ingest")
 QUEUE_STOP_VALUE = -1
 
 
-def construct_model(tag, item, jsonify_content=True):
+def construct_model(tag, item):
     _logger.debug(f"construct_model: {tag=}, {item=}")
     if tag == "VariationArchive":
         _logger.debug("Returning new VariationArchive")
-        return VariationArchive.from_xml(item, jsonify_content=jsonify_content)
+        return VariationArchive.from_xml(item)
     else:
         raise ValueError(f"Unexpected tag: {tag} {item=}")
 
@@ -102,16 +102,14 @@ def _handle_text_nodes(path, key, value) -> Tuple[Any, Any]:
     return (key, value)
 
 
-def _parse_xml_document(doc_str: str):
+def _parse_xml_document(doc_str: str | bytes):
     """
     Reads an XML document from a string.
     """
     return xmltodict.parse(doc_str, postprocessor=_handle_text_nodes)
 
 
-def read_clinvar_xml(
-    reader: TextIO, disassemble=True, jsonify_content=True
-) -> Iterator[Model]:
+def read_clinvar_xml(reader: TextIO, disassemble=True) -> Iterator[Model]:
     """
     Generator function that reads a ClinVar Variation XML file and outputs objects.
     Accepts `reader` as a readable TextIO/BytesIO object, or a filename.
@@ -151,9 +149,7 @@ def read_clinvar_xml(
                         f"parsed dict had more than 1 key: ({elem_d.keys()}) {elem_d}"
                     )
                 tag, contents = list(elem_d.items())[0]
-                model_obj = construct_model(
-                    tag, contents, jsonify_content=jsonify_content
-                )
+                model_obj = construct_model(tag, contents)
                 if disassemble:
                     for subobj in model_obj.disassemble():
                         yield subobj

--- a/clinvar_ingest/utils.py
+++ b/clinvar_ingest/utils.py
@@ -2,7 +2,7 @@ import time
 from typing import Any, List
 
 
-def extract_oneof(d: dict, *keys: List[Any]) -> Any:
+def extract_oneof(d: dict, *keys: Any) -> Any:
     """
     For each key in `keys`, if key exists, remove it and return a
     tuple of the key and the value. If not, try the next key.
@@ -15,7 +15,7 @@ def extract_oneof(d: dict, *keys: List[Any]) -> Any:
     return None
 
 
-def extract(d: dict, *keys: List[Any]) -> Any:
+def extract(d: dict, *keys: Any) -> Any:
     """
     For the path of `keys`, get each value in succession. If any key does not exist,
     return None. If all keys exist, return the value of the last key.
@@ -31,7 +31,7 @@ def extract(d: dict, *keys: List[Any]) -> Any:
             return None
 
 
-def get(d: dict, *keys: List[Any]) -> Any:
+def get(d: dict, *keys: Any) -> Any:
     """
     Traverses the path of `keys` in `d` and returns the value.
     If any key does not exist, returns None.

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -1,5 +1,3 @@
-import json
-
 from clinvar_ingest.model.trait import (
     ClinicalAssertionTrait,
     ClinicalAssertionTraitSet,
@@ -69,7 +67,11 @@ def test_read_original_clinvar_variation_2():
     # Test that included fields were not included in content
     assert "@VariationID" not in variation.content
     assert "GeneList" not in variation.content
-    assert "SequenceLocation" in variation.content
+    assert "SequenceLocation" in variation.content["Location"]
+    assert (
+        variation.content["OtherNameList"]["Name"]["$"]
+        == "AP5Z1, 4-BP DEL/22-BP INS, NT80"
+    )
 
     # Verify gene association
     gene = list(filter(lambda o: isinstance(o, Gene), objects))[0]
@@ -229,7 +231,13 @@ def test_read_original_clinvar_variation_634266(log_conf):
 
     # Test that included fields were not included in content
     # assert "@VariationID" not in variation.content  # TODO - broken
-    assert "GeneList" in variation.content
+    assert variation.content["Haplotype"][0]["@VariationID"] == "633847"
+    assert (
+        variation.content["Haplotype"][0]["SimpleAllele"][0]["GeneList"]["Gene"][
+            "@Symbol"
+        ]
+        == "CYP2C19"
+    )
 
     # SCVs - TODO build out further
     # SCV 1
@@ -546,8 +554,8 @@ def test_read_original_clinvar_variation_10():
         o for o in objects if isinstance(o, ClinicalAssertionTrait)
     ]
     # parse xrefs
-    for t in clinical_assertion_traits:
-        t.xrefs = [Trait.XRef(**json.loads(xref)) for xref in t.xrefs]
+    # for t in clinical_assertion_traits:
+    #     t.xrefs = [Trait.XRef(**json.loads(xref)) for xref in t.xrefs]
     assert len(clinical_assertion_traits) > 0
 
     traits_HP_0000836 = [

--- a/test/test_trait.py
+++ b/test/test_trait.py
@@ -1,4 +1,3 @@
-import json
 from typing import List
 
 from clinvar_ingest.model.common import dictify
@@ -36,7 +35,7 @@ def test_trait_from_xml_32():
     interp_traitset = interp["ConditionList"]["TraitSet"]
     raw_trait = interp_traitset["Trait"]  # only 1 trait in this example
 
-    trait = Trait.from_xml(raw_trait)
+    trait: Trait = Trait.from_xml(raw_trait)
 
     assert trait.id == "9592"
     assert trait.type == "Disease"
@@ -130,7 +129,7 @@ def test_trait_from_xml_32():
         },
     ]
     assert unordered_dict_list_equal(
-        expected_trait_xrefs, dictify([json.loads(x) for x in trait.xrefs])
+        expected_trait_xrefs, [dictify(x) for x in trait.xrefs]
     )
 
 
@@ -151,9 +150,9 @@ def test_trait_from_xml_6619():
     # This trait has a preferred symbol
     assert trait.symbol == "ARVD"
 
-    # This trait has multiple XRefs on Name(Preffered) and Name(Alternate)
-    trait_xrefs = dictify([json.loads(x) for x in trait.xrefs])
-    ## Name(Preffered)
+    # This trait has multiple XRefs on Name(Preferred) and Name(Alternate)
+    trait_xrefs = [dictify(x) for x in trait.xrefs]
+    ## Name(Preferred)
     assert {
         "db": "Genetic Alliance",
         "id": "Arrhythmogenic+Right+Ventricular+Cardiomyopathy/587",
@@ -230,15 +229,13 @@ def test_trait_from_xml_3510():
     # This trait has an attribute_content array because it has multiple GARD ids
     assert len(trait.attribute_content) == 1
     assert trait.attribute_content == [
-        json.dumps(
-            {
-                "Attribute": {
-                    "@Type": "GARD id",
-                    "@integerValue": "5289",
-                },
-                "XRef": {"@ID": "5289", "@DB": "Office of Rare Diseases"},
-            }
-        )
+        {
+            "Attribute": {
+                "@Type": "GARD id",
+                "@integerValue": "5289",
+            },
+            "XRef": {"@ID": "5289", "@DB": "Office of Rare Diseases"},
+        }
     ]
 
 
@@ -269,7 +266,7 @@ def test_trait_from_xml_406155():
         "type": None,
         "ref_field": "public_definition",
         "ref_field_element": None,
-    } in dictify([json.loads(x) for x in trait.xrefs])
+    } in [dictify(x) for x in trait.xrefs]
 
 
 def test_trait_set_from_xml_10():
@@ -324,7 +321,7 @@ def test_trait_set_from_xml_10():
     ]
 
     # test content
-    assert ts13451.content == json.dumps({"@ContributesToAggregateClinsig": "true"})
+    assert ts13451.content == {"@ContributesToAggregateClinsig": "true"}
 
 
 def test_trait_mapping_10():


### PR DESCRIPTION
The benefit to this is that the parsing code doesn't have to worry about json serialization of any fields. The Model `from_xml` method signatures are also simpler and don't need to propagate the `jsonify_content` flag. The `parse_and_write_files` function can just serialize the appropriate fields before writing the objects to the output files. To do this, each Model class needs to indicate what fields should be json-serialized. So I added `jsonifiable_fields` as a required abstract method and added an implementation to each Model class.

Another benefit to this is that while the Model objects are in memory as Python objects, the content fields are kept as dicts, which makes looking into them easier than when they were massive JSON strings.