### PR TITLE
Minor change to descendant_tree to apply recent Haplotype changes to SimpleAllele and add a self-contained test

### DIFF
--- a/clinvar_ingest/model/variation_archive.py
+++ b/clinvar_ingest/model/variation_archive.py
@@ -628,7 +628,7 @@ class Variation(Model):
         return obj
 
     @staticmethod
-    def descendant_tree(inp: dict, caller: bool = None):
+    def descendant_tree(inp: dict, caller: bool = False):
         """
         Accepts xmltodict parsed XML for a SimpleAllele, Haplotype, or Genotype.
         Returns a tree of child ids. Each level is a list, where the first element
@@ -645,7 +645,12 @@ class Variation(Model):
         outputs = []
         if "SimpleAllele" in inp:
             simple_alleles = ensure_list(inp["SimpleAllele"])
-            outputs.extend([[a["@VariationID"]] for a in simple_alleles])
+            for sa in simple_alleles:
+                node = [sa["@VariationID"]]
+                if caller:
+                    outputs.append(node)
+                else:
+                    outputs.extend(node)
 
         if "Haplotype" in inp:
             haplotypes = ensure_list(inp["Haplotype"])
@@ -668,10 +673,10 @@ class Variation(Model):
                 #           [simpleallele_id12]]
                 #        [haplotype_id2,
                 #           [simpleallele_id21]]]
-                if caller is None:
-                    outputs.extend(node)
-                else:
+                if caller:
                     outputs.append(node)
+                else:
+                    outputs.extend(node)
 
         if "Genotype" in inp:
             genotypes = ensure_list(inp["Genotype"])

--- a/test/test_variation.py
+++ b/test/test_variation.py
@@ -24,6 +24,78 @@ def test_variation_descendant_tree_genotype_with_haplotypes():
     assert expected_tree == descendant_tree
 
 
+def test_simple_test_descendant_tree_all_types():
+    simple_allele1 = {
+        "@VariationID": "SimpleAllele1",
+    }
+    simple_allele2 = {
+        "@VariationID": "SimpleAllele2",
+    }
+    simple_allele3 = {
+        "@VariationID": "SimpleAllele3",
+    }
+    haplotype1 = {
+        "@VariationID": "Haplotype1",
+        "SimpleAllele": [simple_allele1, simple_allele2],
+    }
+    haplotype2 = {
+        "@VariationID": "Haplotype2",
+        "SimpleAllele": [simple_allele3],
+    }
+    genotype = {
+        "@VariationID": "Genotype1",
+        "Haplotype": [haplotype1, haplotype2],
+    }
+    genotype_descendant_tree = Variation.descendant_tree({"Genotype": genotype})
+    expected_genotype_descendant_tree = [
+        "Genotype1",
+        ["Haplotype1", ["SimpleAllele1"], ["SimpleAllele2"]],
+        ["Haplotype2", ["SimpleAllele3"]],
+    ]
+    assert expected_genotype_descendant_tree == genotype_descendant_tree
+
+    expected_genotype_only_descendant_tree = ["Genotype2"]
+    genotype_only_descendant_tree = Variation.descendant_tree(
+        {
+            "Genotype": {
+                "@VariationID": "Genotype2",
+            }
+        }
+    )
+    assert expected_genotype_only_descendant_tree == genotype_only_descendant_tree
+
+    haplotype1_descendant_tree = Variation.descendant_tree({"Haplotype": haplotype1})
+    expected_haplotype1_descendant_tree = [
+        "Haplotype1",
+        ["SimpleAllele1"],
+        ["SimpleAllele2"],
+    ]
+    assert expected_haplotype1_descendant_tree == haplotype1_descendant_tree
+
+    expected_haplotype_only_descendant_tree = ["Haplotype3"]
+    haplotype_only_descendant_tree = Variation.descendant_tree(
+        {
+            "Haplotype": {
+                "@VariationID": "Haplotype3",
+            }
+        }
+    )
+    assert expected_haplotype_only_descendant_tree == haplotype_only_descendant_tree
+
+    haplotype2_descendant_tree = Variation.descendant_tree({"Haplotype": haplotype2})
+    expected_haplotype2_descendant_tree = [
+        "Haplotype2",
+        ["SimpleAllele3"],
+    ]
+    assert expected_haplotype2_descendant_tree == haplotype2_descendant_tree
+
+    simple_allele1_descendant_tree = Variation.descendant_tree(
+        {"SimpleAllele": simple_allele1}
+    )
+    expected_simple_allele1_descendant_tree = ["SimpleAllele1"]
+    assert expected_simple_allele1_descendant_tree == simple_allele1_descendant_tree
+
+
 def test_variation_descendant_tree_haploytpe_with_alleles():
     """
     Test the Variation.descendant_tree method.


### PR DESCRIPTION
Make SimpleAllele descendant_tree handling match haplotype and genotype. Add stripped down descendant_tree test for all types.

This does not affect outputs for real XML inputs because SimpleAlleles don't have descendants, but this does impact intermediate data structures and just makes the layout of the tree for each variant type the same which may help consistency when debugging.

It also adds a test that defines the most simple structure of variants that can be passed into `Variation.descendant_tree` and validates the return value for every type on its own and in combination.