### PR TITLE
Update pylint ruff

### DIFF
--- a/lint
+++ b/lint
@@ -10,7 +10,7 @@ if [[ "$1" == "apply" ]]; then
     # Uses each linter's option to apply the changes if it is supported
     black clinvar_ingest test || had_error=1
     isort clinvar_ingest test || had_error=1
-    ruff --fix clinvar_ingest test || had_error=1
+    ruff check --fix clinvar_ingest test || had_error=1
     pylint --disable=C,R,W clinvar_ingest || had_error=1
 else
     # Check-only mode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,9 @@ dev = [
     "ipykernel",
     "black~=23.9.1",
     "isort~=5.12.0",
-    "ruff~=0.1.5",
+    "ruff~=0.6.3",
     "pytest~=7.4.3",
-    "pylint~=3.0.2",
+    "pylint~=3.2.6",
     "httpx~=0.25.2",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dynamic = ["version"]
 dev = [
     "ipykernel",
     "black~=23.9.1",
-    "isort~=5.12.0",
+    "isort~=5.13.2",
     "ruff~=0.6.3",
     "pytest~=7.4.3",
     "pylint~=3.2.6",


### PR DESCRIPTION
Noticed we were pretty far behind on these, especially `ruff`. Updating them may improve some linting of newer python features in environments like vscode.

No changes to how any of these format code. I'm not including a `black` update here because I'm afraid of the possibility of noise.

One minor change to ruff CLI. The fix mode is now under the `check` subcommand.