### PR TITLE
Fix execute script slack disable

### DIFF
--- a/.github/workflows/deploy-job-main.yaml
+++ b/.github/workflows/deploy-job-main.yaml
@@ -31,7 +31,7 @@ jobs:
       ## Deploy + test VCV pipeline
       - name: set env vars
         run: |
-          export CLINVAR_INGEST_RELEASE_TAG=${{ github.ref_name }}_gh_${{ github.run_number }}
+          export CLINVAR_INGEST_RELEASE_TAG=${{ github.ref_name }}
           export instance_name=clinvar-vcv-ingest
           export file_format=vcv
           echo "instance_name=$instance_name" >> $GITHUB_ENV
@@ -46,12 +46,14 @@ jobs:
         run: |
           export JOB_WAIT=1
           echo "JOB_WAIT=$JOB_WAIT" >> $GITHUB_ENV
-          CLINVAR_INGEST_SLACK_CHANNEL='' bash misc/bin/execute-job.sh vcv-small
+          # Override variables for testing.
+          # Send no slack message and write outputs to a directory including the github run number to avoid collisions.
+          CLINVAR_INGEST_SLACK_CHANNEL='' CLINVAR_INGEST_RELEASE_TAG="${CLINVAR_INGEST_RELEASE_TAG}_gh_${{ github.run_number }}" bash misc/bin/execute-job.sh vcv-small
 
       ## Deploy + test RCV pipeline
       - name: set env vars
         run: |
-          export CLINVAR_INGEST_RELEASE_TAG=${{ github.ref_name }}_gh_${{ github.run_number }}
+          export CLINVAR_INGEST_RELEASE_TAG=${{ github.ref_name }}
           export instance_name=clinvar-rcv-ingest
           export file_format=rcv
           echo "instance_name=$instance_name" >> $GITHUB_ENV
@@ -66,12 +68,14 @@ jobs:
         run: |
           export JOB_WAIT=1
           echo "JOB_WAIT=$JOB_WAIT" >> $GITHUB_ENV
-          CLINVAR_INGEST_SLACK_CHANNEL='' bash misc/bin/execute-job.sh rcv-small
+          # Override variables for testing.
+          # Send no slack message and write outputs to a directory including the github run number to avoid collisions.
+          CLINVAR_INGEST_SLACK_CHANNEL='' CLINVAR_INGEST_RELEASE_TAG="${CLINVAR_INGEST_RELEASE_TAG}_gh_${{ github.run_number }}" bash misc/bin/execute-job.sh rcv-small
 
       ## Deploy copy-only pipeline
       - name: set env vars
         run: |
-          export CLINVAR_INGEST_RELEASE_TAG=${{ github.ref_name }}_gh_${{ github.run_number }}
+          export CLINVAR_INGEST_RELEASE_TAG=${{ github.ref_name }}
           export instance_name=clinvar-ingest-copy-only
           export file_format=vcv
           export clinvar_ingest_cmd=python,/app/workflow-copy-only.py
@@ -87,7 +91,7 @@ jobs:
       ## Deploy BQ Ingest pipeline
       - name: set env vars
         run: |
-          export CLINVAR_INGEST_RELEASE_TAG=${{ github.ref_name }}_gh_${{ github.run_number }}
+          export CLINVAR_INGEST_RELEASE_TAG=${{ github.ref_name }}
           export instance_name=clinvar-bq-ingest
           export clinvar_ingest_cmd=python,/app/bq_ingester.py
           echo "instance_name=$instance_name" >> $GITHUB_ENV

--- a/.github/workflows/deploy-job-main.yaml
+++ b/.github/workflows/deploy-job-main.yaml
@@ -31,11 +31,11 @@ jobs:
       ## Deploy + test VCV pipeline
       - name: set env vars
         run: |
-          export release_tag=${{ github.ref_name }}
+          export CLINVAR_INGEST_RELEASE_TAG=${{ github.ref_name }}_gh_${{ github.run_number }}
           export instance_name=clinvar-vcv-ingest
           export file_format=vcv
           echo "instance_name=$instance_name" >> $GITHUB_ENV
-          echo "release_tag=$release_tag" >> $GITHUB_ENV
+          echo "CLINVAR_INGEST_RELEASE_TAG=$CLINVAR_INGEST_RELEASE_TAG" >> $GITHUB_ENV
           echo "file_format=$file_format" >> $GITHUB_ENV
 
       - name: build and deploy
@@ -51,11 +51,11 @@ jobs:
       ## Deploy + test RCV pipeline
       - name: set env vars
         run: |
-          export release_tag=${{ github.ref_name }}
+          export CLINVAR_INGEST_RELEASE_TAG=${{ github.ref_name }}_gh_${{ github.run_number }}
           export instance_name=clinvar-rcv-ingest
           export file_format=rcv
           echo "instance_name=$instance_name" >> $GITHUB_ENV
-          echo "release_tag=$release_tag" >> $GITHUB_ENV
+          echo "CLINVAR_INGEST_RELEASE_TAG=$CLINVAR_INGEST_RELEASE_TAG" >> $GITHUB_ENV
           echo "file_format=$file_format" >> $GITHUB_ENV
 
       - name: build and deploy
@@ -71,12 +71,12 @@ jobs:
       ## Deploy copy-only pipeline
       - name: set env vars
         run: |
-          export release_tag=${{ github.ref_name }}
+          export CLINVAR_INGEST_RELEASE_TAG=${{ github.ref_name }}_gh_${{ github.run_number }}
           export instance_name=clinvar-ingest-copy-only
           export file_format=vcv
           export clinvar_ingest_cmd=python,/app/workflow-copy-only.py
           echo "instance_name=$instance_name" >> $GITHUB_ENV
-          echo "release_tag=$release_tag" >> $GITHUB_ENV
+          echo "CLINVAR_INGEST_RELEASE_TAG=$CLINVAR_INGEST_RELEASE_TAG" >> $GITHUB_ENV
           echo "clinvar_ingest_cmd=$clinvar_ingest_cmd" >> $GITHUB_ENV
           echo "file_format=$file_format" >> $GITHUB_ENV
 
@@ -84,20 +84,14 @@ jobs:
         run: |
           bash misc/bin/deploy-job.sh
 
-      # - name: run test pipeline
-      #   run: |
-      #     export JOB_WAIT=1
-      #     echo "JOB_WAIT=$JOB_WAIT" >> $GITHUB_ENV
-      #     bash misc/bin/execute-job.sh rcv-small
-
       ## Deploy BQ Ingest pipeline
       - name: set env vars
         run: |
-          export release_tag=${{ github.ref_name }}
+          export CLINVAR_INGEST_RELEASE_TAG=${{ github.ref_name }}_gh_${{ github.run_number }}
           export instance_name=clinvar-bq-ingest
           export clinvar_ingest_cmd=python,/app/bq_ingester.py
           echo "instance_name=$instance_name" >> $GITHUB_ENV
-          echo "release_tag=$release_tag" >> $GITHUB_ENV
+          echo "CLINVAR_INGEST_RELEASE_TAG=$CLINVAR_INGEST_RELEASE_TAG" >> $GITHUB_ENV
           echo "clinvar_ingest_cmd=$clinvar_ingest_cmd" >> $GITHUB_ENV
 
       - name: build and deploy

--- a/misc/bin/execute-job.sh
+++ b/misc/bin/execute-job.sh
@@ -8,16 +8,10 @@
 
 
 set -xeo pipefail
-if [ -z "$release_tag" ]; then
-    release_tag="missing_release_tag" # ensure underscore separators for BQ naming
-else
-    echo "release_tag set in environment"
-fi
 
 if [ -z "$instance_name" ]; then
-    instance_name="clinvar-ingest-${release_tag}"
-else
-    echo "instance_name set in environment"
+    echo "Must set instance_name"
+    exit 1
 fi
 
 if [ "$JOB_WAIT" == "1" ]; then
@@ -26,7 +20,6 @@ else
     wait_opt="--async" # the default
 fi
 
-job_name=$instance_name
 region="us-east1"
 
 # Global Variables
@@ -119,6 +112,9 @@ env_vars="CLINVAR_INGEST_BUCKET=$CLINVAR_INGEST_BUCKET"
 if [[ -v CLINVAR_INGEST_SLACK_CHANNEL ]]; then
     env_vars="$env_vars,CLINVAR_INGEST_SLACK_CHANNEL=$CLINVAR_INGEST_SLACK_CHANNEL"
 fi
+if [[ -v CLINVAR_INGEST_RELEASE_TAG ]]; then
+    env_vars="$env_vars,CLINVAR_INGEST_RELEASE_TAG=$CLINVAR_INGEST_RELEASE_TAG"
+fi
 env_vars="$env_vars,host=$host"
 env_vars="$env_vars,directory=$directory"
 env_vars="$env_vars,name=$name"
@@ -128,7 +124,7 @@ env_vars="$env_vars,released=$released"
 env_vars="$env_vars,release_date=$release_date"
 env_vars="$env_vars,file_format=$file_format"
 
-gcloud run jobs execute $job_name \
+gcloud run jobs execute $instance_name \
     --region $region \
     $wait_opt \
     --update-env-vars=$env_vars

--- a/misc/bin/execute-job.sh
+++ b/misc/bin/execute-job.sh
@@ -116,7 +116,7 @@ fi
 
 
 env_vars="CLINVAR_INGEST_BUCKET=$CLINVAR_INGEST_BUCKET"
-if [[ -v "$CLINVAR_INGEST_SLACK_CHANNEL" ]]; then
+if [[ -v CLINVAR_INGEST_SLACK_CHANNEL ]]; then
     env_vars="$env_vars,CLINVAR_INGEST_SLACK_CHANNEL=$CLINVAR_INGEST_SLACK_CHANNEL"
 fi
 env_vars="$env_vars,host=$host"


### PR DESCRIPTION
1. fixes issue in execute-job.sh where the slack message would never be disabled by the github action
2. require `instance_name` to be set explicitly in the execute/deploy scripts
3. when the github action runs the test vcv and rcv file, override the release tag so the outputs get written to a directory specific to this github run