### PR TITLE
#304 Stop stored-procedures job from retrying on failure

### DIFF
--- a/clinvar_ingest/cloud/bigquery/processing_history.py
+++ b/clinvar_ingest/cloud/bigquery/processing_history.py
@@ -691,7 +691,7 @@ def processed_entries_ready_for_sp_processing(
         AND sp_processing_finished IS NULL
     )
     ORDER BY release_date
-    """
+    """  # noqa: S608
     query_job = client.query(query)
     return query_job.result()
 

--- a/clinvar_ingest/cloud/bigquery/processing_history.py
+++ b/clinvar_ingest/cloud/bigquery/processing_history.py
@@ -679,6 +679,17 @@ def processed_entries_ready_for_sp_processing(
     AND bq_processing_finished IS NOT NULL
     AND release_date IS NOT NULL
     AND sp_release_date IS NULL
+    -- Block all new SP work while any SP row is started-but-not-finished.
+    -- The SPs include temporal_data_collection/summation which mutate
+    -- cross-release tables, so running them out of order would corrupt the
+    -- temporal history. This also means a failed SP row acts as a hard stop
+    -- until a human deletes it.
+    AND NOT EXISTS (
+        SELECT 1
+        FROM {processing_history_view_table}
+        WHERE sp_processing_started IS NOT NULL
+        AND sp_processing_finished IS NULL
+    )
     ORDER BY release_date
     """
     query_job = client.query(query)

--- a/misc/bin/deploy-job.sh
+++ b/misc/bin/deploy-job.sh
@@ -145,6 +145,15 @@ if [ $service == "null" || $component == "null" ]; then
 fi
 #####
 
+# stored-procedures must not retry on failure: a failure there almost always
+# indicates a data issue that needs manual intervention, and retrying would
+# just produce an avalanche of Slack failure messages and repeated partial
+# mutations to cross-release temporal tables.
+extra_args=()
+if [[ "$instance_name" == *stored-procedures* ]]; then
+    extra_args+=(--max-retries=0)
+fi
+
 gcloud run jobs $command $instance_name \
       --cpu=2 \
       --memory=8Gi \
@@ -155,7 +164,8 @@ gcloud run jobs $command $instance_name \
       --service-account=$pipeline_service_account \
       --set-env-vars=$env_vars \
       --set-secrets=CLINVAR_INGEST_SLACK_TOKEN=clinvar-ingest-slack-token:latest \
-      --labels=service="clinvar-ingest",component=$instance_name
+      --labels=service="clinvar-ingest",component=$instance_name \
+      "${extra_args[@]}"
 
 if [[ $instance_name =~ ^.*bq-ingest.*$|^.*stored-procedures.*$ ]]; then
     # turn off file globbing

--- a/misc/bin/stored-procedures-workflow.py
+++ b/misc/bin/stored-procedures-workflow.py
@@ -88,10 +88,9 @@ for row in rows_needing_sp_run:
         """
     _logger.info(msg)
 
-# variation_identity export failures are recorded but do not halt the loop
-# (see VI except block below), so that later releases still get their
-# stored procedures run. We exit non-zero at the end if any occurred so
-# Cloud Run marks the execution as Failed.
+# variation_identity export failures are recorded and the loop continues
+# so later releases still get their stored procedures run. The job exits
+# non-zero at the end if any occurred so Cloud Run marks it Failed.
 vi_export_failures: list[str] = []
 
 # Now process individual rows
@@ -133,26 +132,31 @@ for idx, row in enumerate(rows_to_ingest):
         send_slack_message(msg)
     except Exception as e:
         # This run claimed every eligible release via write_started up front,
-        # so any release that did not reach write_finished is now stuck:
-        # the failing release itself, plus any later releases in this batch
-        # that were pre-claimed but never attempted. All of them need their
-        # sp processing_history rows cleared before the job will resume.
-        unattempted = [r["vcv_xml_release_date"].isoformat() for r in rows_to_ingest[idx + 1 :]]
-        unattempted_desc = (
-            f" Additionally, the following releases were pre-claimed earlier "
-            f"in this run but never attempted and also need their sp rows "
-            f"cleared: {', '.join(unattempted)}."
-            if unattempted
+        # so any release that did not reach write_finished is now stuck: the
+        # failing release itself plus any later releases in this batch that
+        # were pre-claimed but never attempted. All of them need their sp
+        # processing_history rows cleared before the job will resume.
+        stuck_releases = [vcv_xml_release_date.isoformat()] + [
+            r["vcv_xml_release_date"].isoformat() for r in rows_to_ingest[idx + 1 :]
+        ]
+        batch_note = (
+            f" This run claimed {len(rows_to_ingest)} releases as a batch "
+            f"at startup ({', '.join(r['vcv_xml_release_date'].isoformat() for r in rows_to_ingest)}) "
+            f"but did not complete all of them."
+            if len(rows_to_ingest) > 1
             else ""
         )
         msg = (
             f"Stored procedure execution failed for release dated "
             f"vcv_xml_release_date={vcv_xml_release_date.isoformat()} "
-            f"{vcv_pipeline_version=} release_tag={env.release_tag}. "
+            f"{vcv_pipeline_version=} release_tag={env.release_tag}.{batch_note} "
             f"The job will NOT retry automatically and is now paused until "
-            f"this is resolved.{unattempted_desc} Investigate the failure, "
-            f"then delete all stuck sp rows from processing_history to "
-            f"resume processing: "
+            f"this is resolved. The following release(s) have stuck sp "
+            f"processing_history rows that must be deleted before the job "
+            f"resumes (this includes the failing release and any later "
+            f"releases in this batch that were pre-claimed but never "
+            f"attempted): {', '.join(stuck_releases)}. Investigate the "
+            f"failure, then run: "
             f"DELETE FROM `{processing_history_table}` "
             f"WHERE pipeline_version = '{env.release_tag}' "
             f"AND file_type = '{ClinVarIngestFileFormat.SP.value}' "

--- a/misc/bin/stored-procedures-workflow.py
+++ b/misc/bin/stored-procedures-workflow.py
@@ -5,7 +5,6 @@
 
 import logging
 import sys
-import traceback
 
 from google.cloud import bigquery
 
@@ -28,42 +27,6 @@ def _get_bq_client() -> bigquery.Client:
         setattr(_get_bq_client, "client", bigquery.Client())
     return getattr(_get_bq_client, "client")
 
-
-################################################################
-### rollback exception handler for deleting processing_history entries
-
-rollback_rows = []
-
-
-def sp_rollback_exception_handler(exc_type, exc_value, exc_traceback):
-    """
-    https://docs.python.org/3/library/sys.html#sys.excepthook
-    """
-    exception_details = "".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
-
-    # Log the exception
-    _logger.error("Uncaught exception:\n%s", exception_details)
-
-    _logger.warning("Rolling back started SP ingest rows.")
-    for row in rollback_rows:
-        _logger.info(f"Rolling back row: {row}")
-        c = processing_history.delete(
-            processing_history_table=row["processing_history_table"],
-            release_tag=row["release_tag"],
-            file_type=row["file_type"],
-            xml_release_date=row["xml_release_date"],
-            client=_get_bq_client(),
-        )
-        _logger.info(f"Deleted {c} rows from processing_history.")
-
-    # Call the default exception handler
-    sys.__excepthook__(exc_type, exc_value, exc_traceback)
-
-
-# Add the exception handler as the global exception handler.
-# NOTE: this modifies global state and will affect all subsequent exceptions
-# in this script or any other script which imports this script.
-sys.excepthook = sp_rollback_exception_handler
 
 ################################################################
 ### Initialization code
@@ -125,18 +88,14 @@ for row in rows_needing_sp_run:
         """
     _logger.info(msg)
 
-    # Add the started row to the rollback list
-    rollback_rows.append(
-        {
-            "processing_history_table": processing_history_table,
-            "release_tag": env.release_tag,
-            "file_type": env.file_format_mode,
-            "xml_release_date": str(vcv_xml_release_date),
-        }
-    )
+# variation_identity export failures are recorded but do not halt the loop
+# (see VI except block below), so that later releases still get their
+# stored procedures run. We exit non-zero at the end if any occurred so
+# Cloud Run marks the execution as Failed.
+vi_export_failures: list[str] = []
 
 # Now process individual rows
-for row in rows_to_ingest:
+for idx, row in enumerate(rows_to_ingest):
     _logger.info(row)
     # required
     release_date = row["release_date"]
@@ -173,19 +132,36 @@ for row in rows_to_ingest:
         _logger.info(msg)
         send_slack_message(msg)
     except Exception as e:
-        msg = f"""
-              Stored procedure execution failed for release dated vcv_xml_release_date={vcv_xml_release_date.isoformat()} {vcv_pipeline_version=} release_tag={env.release_tag}.
-              """
+        # This run claimed every eligible release via write_started up front,
+        # so any release that did not reach write_finished is now stuck:
+        # the failing release itself, plus any later releases in this batch
+        # that were pre-claimed but never attempted. All of them need their
+        # sp processing_history rows cleared before the job will resume.
+        unattempted = [r["vcv_xml_release_date"].isoformat() for r in rows_to_ingest[idx + 1 :]]
+        unattempted_desc = (
+            f" Additionally, the following releases were pre-claimed earlier "
+            f"in this run but never attempted and also need their sp rows "
+            f"cleared: {', '.join(unattempted)}."
+            if unattempted
+            else ""
+        )
+        msg = (
+            f"Stored procedure execution failed for release dated "
+            f"vcv_xml_release_date={vcv_xml_release_date.isoformat()} "
+            f"{vcv_pipeline_version=} release_tag={env.release_tag}. "
+            f"The job will NOT retry automatically and is now paused until "
+            f"this is resolved.{unattempted_desc} Investigate the failure, "
+            f"then delete all stuck sp rows from processing_history to "
+            f"resume processing: "
+            f"DELETE FROM `{processing_history_table}` "
+            f"WHERE pipeline_version = '{env.release_tag}' "
+            f"AND file_type = '{ClinVarIngestFileFormat.SP.value}' "
+            f"AND processing_finished IS NULL;  "
+            f"Error: {e}"
+        )
         _logger.error(msg)
         send_slack_message(msg)
         raise e
-
-    # Remove the started row from the rollback list, since this ingest has succeeded
-    rollback_rows = [
-        row
-        for row in rollback_rows
-        if row["xml_release_date"] != str(vcv_xml_release_date) or row["release_tag"] != env.release_tag
-    ]
 
     vi_gs_url = f"gs://{env.clinvar_gks_bucket}/{release_date}/dev/vi.jsonl.gz"
     try:
@@ -200,7 +176,29 @@ for row in rows_to_ingest:
         _logger.info(msg)
         send_slack_message(msg)
     except Exception as e:
-        error_msg = f"BigQuery extract job to {vi_gs_url} failed: {e}"
+        # VI export is a BQ-to-GCS extract_table deliverable, not a data
+        # mutation. Record the failure and continue processing later releases
+        # so a flaky export on one release does not block stored procedure
+        # execution for the rest of the batch. We exit non-zero after the
+        # loop so Cloud Run still marks the execution as Failed.
+        vi_export_failures.append(vcv_xml_release_date.isoformat())
+        error_msg = (
+            f"variation_identity export failed for release dated "
+            f"vcv_xml_release_date={vcv_xml_release_date.isoformat()} "
+            f"{vcv_pipeline_version=} release_tag={env.release_tag}. "
+            f"Stored procedures already completed for this release, so its "
+            f"sp processing_history row is finished and does NOT need to be "
+            f"deleted. The SP job is NOT paused and will continue processing "
+            f"the remaining releases in this run. Re-run the BigQuery extract "
+            f"manually to {vi_gs_url} after investigating. "
+            f"Error: {e}"
+        )
         _logger.error(error_msg)
         send_slack_message(error_msg)
-        raise e
+
+if vi_export_failures:
+    sys.exit(
+        f"variation_identity export failed for {len(vi_export_failures)} "
+        f"release(s): {', '.join(vi_export_failures)}. See earlier Slack "
+        f"messages for details."
+    )


### PR DESCRIPTION
Close #304

## Summary
- Disable Cloud Run retries for the stored-procedures job (`--max-retries=0`) so a data-driven SP failure does not produce an avalanche of retry Slack messages or repeated partial mutations to cross-release temporal tables.
- Gate SP eligibility on "no started-but-unfinished SP row anywhere in the env's processing_history_view," so a stuck SP row is a hard stop until a human clears it.
- Replace the excepthook-based rollback with explicit, operator-actionable error messages: on SP failure the Slack/log message now enumerates every stuck release (the failing one plus any later releases in the batch that were pre-claimed at startup but never attempted) and includes the exact DELETE to run to resume processing.
- On variation_identity export failure, record the failure and continue processing later releases in the batch rather than raising. The job still exits non-zero at the end so Cloud Run marks the execution Failed.

## Recovery runbook
When the SP job posts a failure message to Slack:
1. Investigate the underlying error from the message.
2. Run the DELETE statement included in the message — it clears the failing release plus any pre-claimed-but-unattempted releases listed in the message.
3. The next scheduled invocation will re-pick those releases.

For variation_identity export failures the SP rows are already finished and must NOT be deleted — re-run the BigQuery extract manually to the GCS URL shown in the message.

## Test plan
- [ ] Deploy to dev and trigger an SP failure (e.g. via a deliberately broken SP) to verify the Slack message lists all stuck releases and the DELETE clears exactly them.
- [ ] Verify Cloud Run shows `Max retries: 0` on the stored-procedures job after deploy.
- [ ] Verify a VI export failure does not halt the rest of the batch and the job still exits Failed.
- [ ] Verify a new SP run will not start while any `sp_processing_started IS NOT NULL AND sp_processing_finished IS NULL` row exists in the env's processing_history_view.